### PR TITLE
Remove jail from the oracle module

### DIFF
--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -312,10 +312,9 @@ func TestEndblocker(t *testing.T) {
 		err = Endblocker(ctx, oracleKeeper)
 		require.NoError(t, err)
 
-		// Check if validator was jailed
+		// Get the validator
 		validator, err := oracleKeeper.StakingKeeper.Validator(ctx, operator)
 		require.NoError(t, err)
-		require.True(t, validator.IsJailed())
 
 		// Check if validator was slashed (power reduced)
 		slashedPower := validator.GetConsensusPower(stakingKeeper.PowerReduction(ctx))

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -19,7 +19,7 @@ func GetTxCmd() *cobra.Command {
 	// Register the oracle transactions subcommands
 	oracleTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,
-		Short:                      "Oracle transmition subcommands",
+		Short:                      "Oracle transmission subcommands",
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -59,10 +59,6 @@ func (k Keeper) SlashAndResetCounters(ctx sdk.Context) error {
 				if err != nil {
 					return true, err
 				}
-				err = k.StakingKeeper.Jail(ctx, consAddr) // Jail validator
-				if err != nil {
-					return true, err
-				}
 			}
 		}
 

--- a/x/oracle/keeper/slash_test.go
+++ b/x/oracle/keeper/slash_test.go
@@ -109,7 +109,6 @@ func TestSlashAndResetMissCounters(t *testing.T) {
 		require.NoError(t, err)
 		validator, _ := stakingKeeper.GetValidator(input.Ctx, ValAddrs[0])
 		require.Equal(t, amount.Sub(slashFraction.MulInt(amount).TruncateInt()), validator.GetBondedTokens())
-		require.True(t, validator.IsJailed())
 	})
 
 	t.Run("slash and jail for abstaining too much along with misses", func(t *testing.T) {
@@ -134,7 +133,6 @@ func TestSlashAndResetMissCounters(t *testing.T) {
 
 		// slashing for not voting validly sufficiently
 		require.Equal(t, amount.Sub(slashFraction.MulInt(amount).TruncateInt()), validator.GetBondedTokens())
-		require.True(t, validator.IsJailed())
 	})
 
 	t.Run("slash unbonded validator", func(t *testing.T) {

--- a/x/oracle/types/expected_keepers.go
+++ b/x/oracle/types/expected_keepers.go
@@ -18,7 +18,6 @@ type StakingKeeper interface {
 	Validator(ctx context.Context, address sdk.ValAddress) (stakingtypes.ValidatorI, error)                                           // Retrieves a validator's information
 	TotalBondedTokens(ctx context.Context) (math.Int, error)                                                                          // Retrieves total staked tokens (useful for slashing calculations)
 	Slash(ctx context.Context, consAddr sdk.ConsAddress, infractionHeight, power int64, slashFactor math.LegacyDec) (math.Int, error) // Slashes a validator or delegate who fails to vote in the oracle
-	Jail(ctx context.Context, consAddr sdk.ConsAddress) error                                                                         // Jail a validator or delegator
 	ValidatorsPowerStoreIterator(ctx context.Context) (corestore.Iterator, error)                                                     // Used to computing validator rankings or total power
 	MaxValidators(ctx context.Context) (uint32, error)                                                                                // Return the maximum amount of bonded validators
 	PowerReduction(ctx context.Context) (res math.Int)                                                                                // Returns the power reduction factor,


### PR DESCRIPTION
# Description

This removes the jailing of validators from the oracle module

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tests were updated
