### PR TITLE
test: add TestBasicCoinMath for sdk.Int operation

### DIFF
--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+    "testing"
+
+    sdk "cosmossdk.io/math"
+    "github.com/stretchr/testify/require"
+)
+
+func TestBasicCoinMath(t *testing.T) {
+    amt1 := sdk.NewInt(100)
+    amt2 := sdk.NewInt(50)
+    total := amt1.Add(amt2)
+
+    require.Equal(t, sdk.NewInt(150), total, "Total harus 150")
+}
+


### PR DESCRIPTION
### 📌 PR Description

Add a unit test `TestBasicCoinMath` for simple `sdk.Int` addition in `x/bank/keeper`.  
This test ensures the accuracy of basic math using Cosmos SDK types.

### ✅ Changes
- Add `keeper_test.go` with a simple test using `require.Equal`

### 🧪 How to Test
```bash
go test -v ./x/bank/keeper/