### PR TITLE
chore: add pre-commit config for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,10 @@ repos:
       - id: golangci-lint
         args: ["--timeout=5m"]
 
-  - repo: https://github.com/markdownlint/markdownlint
-    rev: v0.11.0
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.40.0
     hooks:
-      - id: markdownlint
+      - id: markdownlint-cli
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.32.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.59.0
+    hooks:
+      - id: golangci-lint
+        args: ["--timeout=5m"]
+
+  - repo: https://github.com/markdownlint/markdownlint
+    rev: v0.11.0
+    hooks:
+      - id: markdownlint
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.32.0
+    hooks:
+      - id: yamllint
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v3.0.1 — 2025-07-31
+
+### Changed
+
+- Switched markdown linting hook to `markdownlint-cli` for faster CI and better compatibility
+- Fixed incorrect Markdown code block formatting in `README.md`
+
 ## v3.0.0 — 2025-07-01
 
 No changes were made since the release candidate.

--- a/README.md
+++ b/README.md
@@ -79,15 +79,22 @@ To enable the hooks on your local environment:
 
 1. Install `pre-commit` (requires Python):
 
-   pip install pre-commit
+    ```bash
+    pip install pre-commit
+    ```
 
 2. Install the hooks defined in the config:
 
-   pre-commit install
+    ```bash
+    pre-commit install
+    ```
 
 3. (Optional) Run all hooks on all files:
 
-   pre-commit run --all-files
+    ```bash
+    pre-commit run --all-files
+    ```
+
 
 ### ✅ Enabled Hooks
 

--- a/README.md
+++ b/README.md
@@ -66,3 +66,34 @@ The Kiichain is licensed under [Apache License 2.0][license].
 [coc]: ./CODE_OF_CONDUCT.md
 [issues]: https://github.com/kiichain/kiichain/issues
 [license]: ./LICENSE
+
+---
+
+## 🧹 Pre-commit Hook Support
+
+This repository supports [pre-commit](https://pre-commit.com/) hooks for automatic linting before each commit. It helps enforce code quality and consistency across the codebase.
+
+### 🔧 Setup Instructions
+
+To enable the hooks on your local environment:
+
+1. Install `pre-commit` (requires Python):
+
+   pip install pre-commit
+
+2. Install the hooks defined in the config:
+
+   pre-commit install
+
+3. (Optional) Run all hooks on all files:
+
+   pre-commit run --all-files
+
+### ✅ Enabled Hooks
+
+- golangci-lint: Linter for Go code  
+- markdownlint: Linter for Markdown files  
+- yamllint: Linter for YAML files  
+
+🗂️ Configuration file: `.pre-commit-config.yaml` (located at the project root).
+


### PR DESCRIPTION
Description:

This PR adds a .pre-commit-config.yaml file with support for :
- golangci-lint for Go code
- markdownlint for Markdown files
- yamllint for YAML files

Also updated README.md with setup instructions to help contributors install and use pre-commit.
This promotes better code consistency and reduces manual review effort.