### PR TITLE
Fix awful math on price calculation

### DIFF
--- a/x/feeabstraction/ante/cosmos/fee.go
+++ b/x/feeabstraction/ante/cosmos/fee.go
@@ -135,7 +135,7 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 		// Apply the fee conversion from the fee abstraction module
 		// This is the only change from the original implementation
 		var err error
-		convertedFee, err := dfd.feeAbstractionKeeper.ConvertNativeFee(ctx, deductFeesFromAcc.GetAddress(), fee)
+		convertedFee, err = dfd.feeAbstractionKeeper.ConvertNativeFee(ctx, deductFeesFromAcc.GetAddress(), fee)
 		if err != nil {
 			return err
 		}

--- a/x/feeabstraction/types/fee.go
+++ b/x/feeabstraction/types/fee.go
@@ -17,7 +17,7 @@ func CalculateTokenPrice(
 	}
 
 	// Get the quotient between the two tokens
-	price := other.Quo(base)
+	price := base.Quo(other)
 
 	// Return the calculated price
 	return price, nil

--- a/x/feeabstraction/types/fee_test.go
+++ b/x/feeabstraction/types/fee_test.go
@@ -20,31 +20,49 @@ func TestCalculateTokenPrice(t *testing.T) {
 		errContains string
 	}{
 		{
-			base:     math.LegacyNewDec(100),
-			other:    math.LegacyNewDec(200),
-			expected: math.LegacyNewDec(2),
+			// Situation where both KII and TokenB have the same USD price
+			// 1 KII = 1 USD and 1 TokenB = 1 USD
+			// This means 1 KII = 1 TokenB
+			base:     math.LegacyMustNewDecFromStr("1"),
+			other:    math.LegacyMustNewDecFromStr("1"),
+			expected: math.LegacyMustNewDecFromStr("1"),
+		},
+		{
+			// Situation where KII is more expensive than TokenB
+			// 1 KII = 20 USD and 1 TokenB = 5 USD
+			// This means 1 KII = 4 TokenB
+			base:     math.LegacyMustNewDecFromStr("20"),
+			other:    math.LegacyMustNewDecFromStr("5"),
+			expected: math.LegacyMustNewDecFromStr("4"),
+		},
+		{
+			// Simple situation where kii is worth 0.01 USD and the asset B is worth 1 USD
+			// This would mean that 1 KII = 0.01 TokenB
+			base:     math.LegacyMustNewDecFromStr("0.01"),
+			other:    math.LegacyMustNewDecFromStr("1"),
+			expected: math.LegacyMustNewDecFromStr("0.01"),
 		},
 		{
 			// Simulate a real situation, where kii is worth 0.1 USD and the asset B is worth 15 USD
-			// This would mean that 1 KII = 150 TokenB
+			// This would mean that 1 KII = 0.0066 TokenB
 			base:     math.LegacyMustNewDecFromStr("0.1"),
 			other:    math.LegacyMustNewDecFromStr("15"),
-			expected: math.LegacyMustNewDecFromStr("150"),
+			expected: math.LegacyMustNewDecFromStr("0.006666666666666667"),
 		},
 		{
-			base:        math.LegacyNewDec(0),
-			other:       math.LegacyNewDec(100),
+			base:        math.LegacyMustNewDecFromStr("0"),
+			other:       math.LegacyMustNewDecFromStr("100"),
 			errContains: "invalid input: base or other is zero",
 		},
 		{
-			base:        math.LegacyNewDec(100),
-			other:       math.LegacyNewDec(0),
+			base:        math.LegacyMustNewDecFromStr("100"),
+			other:       math.LegacyMustNewDecFromStr("0"),
 			expected:    math.LegacyDec{},
 			errContains: "invalid input: base or other is zero",
 		},
 		{
-			base:        math.LegacyNewDec(0),
-			other:       math.LegacyNewDec(0),
+			base:        math.LegacyMustNewDecFromStr("0"),
+			other:       math.LegacyMustNewDecFromStr("0"),
 			expected:    math.LegacyDec{},
 			errContains: "invalid input: base or other is zero",
 		},


### PR DESCRIPTION
# Description

This fixes the bad math on the fee calculation:
- Put the correct quocient for the price

No other test had to be changed:
- All other tests use scopped pricing 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tests updated
