### PR TITLE
Add spellcheck CI action for Markdown and Go files #67

### DIFF
--- a/.github/workflows/.cspell.json
+++ b/.github/workflows/.cspell.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "KiiChain",
+    "Tendermint",
+    "EVM",
+    "kiichaind",
+    "Cosmos"
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    "go.mod",
+    "go.sum"
+  ]
+}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,16 @@
+name: Spellcheck
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.go'
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install cspell
+        run: npm install -g cspell
+      - name: Run cspell
+        run: cspell --config .cspell.json "**/*.md" "**/*.go"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install cspell
         run: npm install -g cspell
       - name: Run cspell
-        run: cspell --config .cspell.json "**/*.md" "**/*.go"
+        run: cspell --config .github/workflows/.cspell.json "**/*.md" "**/*.go"


### PR DESCRIPTION
Added GitHub Action to run cspell on .md and .go files, with a custom dictionary for KiiChain terms (e.g., Tendermint, EVM). Addresses #67.

