### PR TITLE
Override EVM chain ID if default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Fixes
 
 - Add missing address validation in `GetTokenfactoryDenomsByCreator` query to prevent potential crashes with malformed addresses
-
+- Override EVM chain ID if default
 
 ## v4.0.0 — 2025-08-06
 

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -175,16 +175,10 @@ func NewRootCmd() *cobra.Command {
 
 			// If the chain id is still default, we override it on the CLI
 			if evmChainId == evmserverconfig.DefaultEVMChainID {
-				err := cmd.Flags().Set(srvflags.EVMChainID, fmt.Sprintf("%d", kiichain.KiichainID))
-				if err != nil {
-					return err
-				}
+				err = cmd.Flags().Set(srvflags.EVMChainID, fmt.Sprintf("%d", kiichain.KiichainID))
 			}
 
 			return err
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-
 		},
 	}
 

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -168,13 +168,13 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			// Read in the client context from the command line and environment variables
-			evmChainId, err := cmd.Flags().GetUint64(srvflags.EVMChainID)
+			evmChainID, err := cmd.Flags().GetUint64(srvflags.EVMChainID)
 			if err != nil {
 				return err
 			}
 
 			// If the chain id is still default, we override it on the CLI
-			if evmChainId == evmserverconfig.DefaultEVMChainID {
+			if evmChainID == evmserverconfig.DefaultEVMChainID {
 				err = cmd.Flags().Set(srvflags.EVMChainID, fmt.Sprintf("%d", kiichain.KiichainID))
 			}
 


### PR DESCRIPTION
# Description

Enforce the in-memory EVM chain ID from Cosmos chain on the CLI command if the value is default

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tested locally
