### PR TITLE
Swap micro coins denom on oracles for non-micro ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Removed wasmd precompile due to vulnerabilities it had
+- Swapped default micro oracle coins to their normal denom
 
 ## v5.0.0 — 2025-09-28
 

--- a/precompiles/oracle/query_test.go
+++ b/precompiles/oracle/query_test.go
@@ -168,7 +168,7 @@ func (s *OraclePrecompileTestSuite) TestGetTwaps() {
 		SnapshotTimestamp: 2,
 		PriceSnapshotItems: []types.PriceSnapshotItem{
 			{
-				Denom: "uusdc",
+				Denom: "usdc",
 				OracleExchangeRate: types.OracleExchangeRate{
 					ExchangeRate:        math.LegacyMustNewDecFromStr("0.5"),
 					LastUpdate:          math.NewIntFromUint64(1000000),
@@ -190,7 +190,7 @@ func (s *OraclePrecompileTestSuite) TestGetTwaps() {
 			name: "valid query - get twaps",
 			args: []any{big.NewInt(2)},
 			expValue: []TwapsResponse{
-				{Denom: "uusdc", Twap: "0.500000000000000000"},
+				{Denom: "usdc", Twap: "0.500000000000000000"},
 			},
 		},
 		{

--- a/tests/e2e/e2e_oracle_test.go
+++ b/tests/e2e/e2e_oracle_test.go
@@ -147,7 +147,7 @@ func (s *IntegrationTestSuite) checkAndUpdateOracleParams() {
 	s.Require().NoError(err, "failed to query oracle parameters")
 
 	// Check if the parameters are set under the expected values
-	expectedWhitelist := []string{"kii"}
+	expectedWhitelist := []string{"akii"}
 	if len(params.Params.Whitelist) == 1 && params.Params.Whitelist[0].Name == expectedWhitelist[0] {
 		s.T().Log("Oracle parameters are already set correctly, skipping update")
 		return
@@ -182,7 +182,7 @@ func (s *IntegrationTestSuite) checkAndUpdateOracleParams() {
 			params, err := queryOracleParameters(chainEndpoint)
 			s.Require().NoError(err, "failed to query oracle parameters after proposal")
 			s.Require().Equal(len(params.Params.Whitelist), 1, "expected one whitelist entry after proposal")
-			s.Require().Equal(params.Params.Whitelist[0].Name, "kii", "expected whitelist entry to be 'kii' after proposal")
+			s.Require().Equal(params.Params.Whitelist[0].Name, "akii", "expected whitelist entry to be 'akii' after proposal")
 
 			return true
 		},
@@ -213,7 +213,7 @@ func (s *IntegrationTestSuite) writeOracleParamChangeProposal(c *chain) {
 					"reward_band": "0.020000000000000000",
 					"whitelist": [
 						{
-							"name": "kii"
+							"name": "akii"
 						}
 					],
 					"slash_fraction": "0.050000000000000000",

--- a/tests/e2e/e2e_oracle_test.go
+++ b/tests/e2e/e2e_oracle_test.go
@@ -147,7 +147,7 @@ func (s *IntegrationTestSuite) checkAndUpdateOracleParams() {
 	s.Require().NoError(err, "failed to query oracle parameters")
 
 	// Check if the parameters are set under the expected values
-	expectedWhitelist := []string{"akii"}
+	expectedWhitelist := []string{"kii"}
 	if len(params.Params.Whitelist) == 1 && params.Params.Whitelist[0].Name == expectedWhitelist[0] {
 		s.T().Log("Oracle parameters are already set correctly, skipping update")
 		return
@@ -182,7 +182,7 @@ func (s *IntegrationTestSuite) checkAndUpdateOracleParams() {
 			params, err := queryOracleParameters(chainEndpoint)
 			s.Require().NoError(err, "failed to query oracle parameters after proposal")
 			s.Require().Equal(len(params.Params.Whitelist), 1, "expected one whitelist entry after proposal")
-			s.Require().Equal(params.Params.Whitelist[0].Name, "akii", "expected whitelist entry to be 'akii' after proposal")
+			s.Require().Equal(params.Params.Whitelist[0].Name, "kii", "expected whitelist entry to be 'kii' after proposal")
 
 			return true
 		},
@@ -213,7 +213,7 @@ func (s *IntegrationTestSuite) writeOracleParamChangeProposal(c *chain) {
 					"reward_band": "0.020000000000000000",
 					"whitelist": [
 						{
-							"name": "akii"
+							"name": "kii"
 						}
 					],
 					"slash_fraction": "0.050000000000000000",

--- a/wasmbinding/oracle/queries_test.go
+++ b/wasmbinding/oracle/queries_test.go
@@ -21,13 +21,13 @@ func TestHandleOracleQuery(t *testing.T) {
 	app, ctx := helpers.SetupCustomApp(t, actor)
 
 	// Create two rates
-	err := app.OracleKeeper.ExchangeRate.Set(ctx, "uusdc", types.OracleExchangeRate{
+	err := app.OracleKeeper.ExchangeRate.Set(ctx, "usdc", types.OracleExchangeRate{
 		ExchangeRate:        math.LegacyMustNewDecFromStr("0.5"),
 		LastUpdate:          math.NewIntFromUint64(1000000),
 		LastUpdateTimestamp: 1000000,
 	})
 	require.NoError(t, err)
-	err = app.OracleKeeper.ExchangeRate.Set(ctx, "akii", types.OracleExchangeRate{
+	err = app.OracleKeeper.ExchangeRate.Set(ctx, "kii", types.OracleExchangeRate{
 		ExchangeRate:        math.LegacyMustNewDecFromStr("125.2"),
 		LastUpdate:          math.NewIntFromUint64(2000000),
 		LastUpdateTimestamp: 2000000,
@@ -39,7 +39,7 @@ func TestHandleOracleQuery(t *testing.T) {
 		SnapshotTimestamp: 2,
 		PriceSnapshotItems: []types.PriceSnapshotItem{
 			{
-				Denom: "uusdc",
+				Denom: "usdc",
 				OracleExchangeRate: types.OracleExchangeRate{
 					ExchangeRate:        math.LegacyMustNewDecFromStr("0.5"),
 					LastUpdate:          math.NewIntFromUint64(1000000),
@@ -61,7 +61,7 @@ func TestHandleOracleQuery(t *testing.T) {
 			name: "Valid - exchange rate",
 			query: oraclebindingtypes.Query{
 				ExchangeRate: &oraclebindingtypes.ExchangeRateQuery{
-					Denom: "uusdc",
+					Denom: "usdc",
 				},
 			},
 			expected: []byte(`{"oracle_exchange_rate":{"exchange_rate":"0.500000000000000000","last_update":"1000000","last_update_timestamp":1000000}}`),
@@ -89,7 +89,7 @@ func TestHandleOracleQuery(t *testing.T) {
 			query: oraclebindingtypes.Query{
 				ExchangeRates: &oraclebindingtypes.ExchangeRatesQuery{},
 			},
-			expected: []byte(`{"denom_oracle_exchange_rate":[{"denom":"akii","oracle_exchange_rate":{"exchange_rate":"125.200000000000000000","last_update":"2000000","last_update_timestamp":2000000}},{"denom":"uusdc","oracle_exchange_rate":{"exchange_rate":"0.500000000000000000","last_update":"1000000","last_update_timestamp":1000000}}]}`),
+			expected: []byte(`{"denom_oracle_exchange_rate":[{"denom":"kii","oracle_exchange_rate":{"exchange_rate":"125.200000000000000000","last_update":"2000000","last_update_timestamp":2000000}},{"denom":"usdc","oracle_exchange_rate":{"exchange_rate":"0.500000000000000000","last_update":"1000000","last_update_timestamp":1000000}}]}`),
 		},
 		{
 			name: "valid - twaps",
@@ -98,7 +98,7 @@ func TestHandleOracleQuery(t *testing.T) {
 					LookbackSeconds: 1000,
 				},
 			},
-			expected: []byte(`{"oracle_twap":[{"denom":"uusdc","twap":"0.500000000000000000","lookback_seconds":1000}]}`),
+			expected: []byte(`{"oracle_twap":[{"denom":"usdc","twap":"0.500000000000000000","lookback_seconds":1000}]}`),
 		},
 		{
 			name: "invalid - twaps bad lookback",

--- a/wasmbinding/oracle/reflect_query_test.go
+++ b/wasmbinding/oracle/reflect_query_test.go
@@ -28,7 +28,7 @@ func TestOracleQueries(t *testing.T) {
 	require.NotEmpty(t, reflect)
 
 	// Create a rate
-	err := app.OracleKeeper.ExchangeRate.Set(ctx, "uusdc", oracletypes.OracleExchangeRate{
+	err := app.OracleKeeper.ExchangeRate.Set(ctx, "usdc", oracletypes.OracleExchangeRate{
 		ExchangeRate:        math.LegacyMustNewDecFromStr("0.5"),
 		LastUpdate:          math.NewIntFromUint64(1000000),
 		LastUpdateTimestamp: 1000000,
@@ -39,7 +39,7 @@ func TestOracleQueries(t *testing.T) {
 		SnapshotTimestamp: 2,
 		PriceSnapshotItems: []oracletypes.PriceSnapshotItem{
 			{
-				Denom: "uusdc",
+				Denom: "usdc",
 				OracleExchangeRate: oracletypes.OracleExchangeRate{
 					ExchangeRate:        math.LegacyMustNewDecFromStr("0.5"),
 					LastUpdate:          math.NewIntFromUint64(1000000),
@@ -53,7 +53,7 @@ func TestOracleQueries(t *testing.T) {
 	// query exchange rate
 	query := oraclebindingtypes.Query{
 		ExchangeRate: &oraclebindingtypes.ExchangeRateQuery{
-			Denom: "uusdc",
+			Denom: "usdc",
 		},
 	}
 	resp := oracletypes.QueryExchangeRateResponse{}
@@ -71,7 +71,7 @@ func TestOracleQueries(t *testing.T) {
 	err = queryCustom(t, ctx, app, reflect, query, &respAll)
 	require.NoError(t, err)
 	require.Len(t, respAll.DenomOracleExchangeRate, 1)
-	require.EqualValues(t, respAll.DenomOracleExchangeRate[0].Denom, "uusdc")
+	require.EqualValues(t, respAll.DenomOracleExchangeRate[0].Denom, "usdc")
 
 	// Query the twaps
 	query = oraclebindingtypes.Query{
@@ -84,7 +84,7 @@ func TestOracleQueries(t *testing.T) {
 	err = queryCustom(t, ctx, app, reflect, query, &respTwaps)
 	require.NoError(t, err)
 	require.Len(t, respTwaps.OracleTwap, 1)
-	require.EqualValues(t, respTwaps.OracleTwap[0].Denom, "uusdc")
+	require.EqualValues(t, respTwaps.OracleTwap[0].Denom, "usdc")
 }
 
 // TestQueryDenomAdmin tests the GetDenomAdmin query

--- a/wasmbinding/tokenfactory/types/types.go
+++ b/wasmbinding/tokenfactory/types/types.go
@@ -20,13 +20,13 @@ type Metadata struct {
 }
 
 type DenomUnit struct {
-	// Denom represents the string name of the given denom unit (e.g uatom).
+	// Denom represents the string name of the given denom unit (e.g akii).
 	Denom string `json:"denom"`
 	// Exponent represents power of 10 exponent that one must
 	// raise the base_denom to in order to equal the given DenomUnit's denom
 	// 1 denom = 1^exponent base_denom
-	// (e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with
-	// exponent = 6, thus: 1 atom = 10^6 uatom).
+	// (e.g. with a base_denom of akii, one can create a DenomUnit of 'kii' with
+	// exponent = 18, thus: 1 kii = 10^18 akii).
 	Exponent uint32 `json:"exponent"`
 	// Aliases is a list of string aliases for the given denom
 	Aliases []string `json:"aliases"`

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -15,10 +15,10 @@ import (
 
 /* SetUp conditions:
 voting target:
-- uatom
-- ueth
-- uusd
-- akii
+- atom
+- eth
+- usd
+- kii
 
 validators:
 - val 1
@@ -26,7 +26,7 @@ validators:
 - val 3
 
 Default Vote Threshold: 66.7%
-bonded tokens: 30 akii
+bonded tokens: 30 kii
 ballot threshold: 20 power units
 
 */
@@ -41,9 +41,9 @@ func TestMidBlocker(t *testing.T) {
 		// Sample exchange rate for the test
 		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 		require.NoError(t, err)
-		err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 		require.NoError(t, err)
-		exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+		exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
 
 		ctx = input.Ctx.WithBlockHeight(1)
 
@@ -59,7 +59,7 @@ func TestMidBlocker(t *testing.T) {
 		err = BeginBlocker(ctx, oracleKeeper)
 		require.NoError(t, err)
 
-		exchangeRateResponse, err := oracleKeeper.ExchangeRate.Get(ctx, utils.MicroAtomDenom)
+		exchangeRateResponse, err := oracleKeeper.ExchangeRate.Get(ctx, utils.AtomDenom)
 		require.NoError(t, err)
 		require.Equal(t, randomAExchangeRate, exchangeRateResponse.ExchangeRate)
 		require.Equal(t, int64(1), exchangeRateResponse.LastUpdate.Int64()) // Last update block should be 1
@@ -74,9 +74,9 @@ func TestMidBlocker(t *testing.T) {
 		// Sample exchange rate for the test
 		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 		require.NoError(t, err)
-		err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 		require.NoError(t, err)
-		exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+		exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
 
 		ctx = input.Ctx.WithBlockHeight(1)
 
@@ -94,7 +94,7 @@ func TestMidBlocker(t *testing.T) {
 
 		// validate snapshot
 		err = oracleKeeper.PriceSnapshot.Walk(ctx, nil, func(_ int64, snapshot types.PriceSnapshot) (bool, error) {
-			require.Equal(t, snapshot.PriceSnapshotItems[0].Denom, utils.MicroAtomDenom)
+			require.Equal(t, snapshot.PriceSnapshotItems[0].Denom, utils.AtomDenom)
 			return false, nil
 		})
 		require.NoError(t, err)
@@ -109,9 +109,9 @@ func TestMidBlocker(t *testing.T) {
 		// Sample exchange rate for the test
 		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 		require.NoError(t, err)
-		err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 		require.NoError(t, err)
-		exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+		exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
 
 		ctx = input.Ctx.WithBlockHeight(1)
 
@@ -125,7 +125,7 @@ func TestMidBlocker(t *testing.T) {
 		err = BeginBlocker(ctx, oracleKeeper)
 		require.NoError(t, err)
 
-		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.MicroAtomDenom)
+		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.AtomDenom)
 		require.Error(t, err)
 	})
 
@@ -138,9 +138,9 @@ func TestMidBlocker(t *testing.T) {
 		// Sample exchange rate for the test
 		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 		require.NoError(t, err)
-		err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 		require.NoError(t, err)
-		exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+		exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
 
 		ctx = input.Ctx.WithBlockHeight(1)
 
@@ -172,14 +172,14 @@ func TestMidBlocker(t *testing.T) {
 		// Sample exchange rate for the test
 		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 		require.NoError(t, err)
-		err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 		require.NoError(t, err)
-		exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+		exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
 
 		ctx = input.Ctx.WithBlockHeight(1)
 
 		// Validator submits an incorrect exchange rate
-		wrongRate := "100000000.0" + utils.MicroAtomDenom
+		wrongRate := "100000000.0" + utils.AtomDenom
 		voteMsg := types.NewMsgAggregateExchangeRateVote(wrongRate, keeper.Addrs[0], keeper.ValAddrs[0])
 		_, err = msgServer.AggregateExchangeRateVote(ctx, voteMsg)
 		require.NoError(t, err)
@@ -210,12 +210,12 @@ func TestMidBlocker(t *testing.T) {
 
 		ctx := input.Ctx.WithBlockHeight(1)
 
-		// Modify the whitelist and apply it (akii and uusdc will be 'new assets')
+		// Modify the whitelist and apply it (kii and usdc will be 'new assets')
 		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 		require.NoError(t, err)
 		newWhitelist := types.DenomList{
-			{Name: utils.MicroAtomDenom},
-			{Name: utils.MicroEthDenom},
+			{Name: utils.AtomDenom},
+			{Name: utils.EthDenom},
 		}
 		params, err := oracleKeeper.Params.Get(ctx)
 		require.NoError(t, err)
@@ -242,11 +242,11 @@ func TestMidBlocker(t *testing.T) {
 
 		// validate the vote target
 		require.NotEqual(t, voteTargetsBefore, voteTargetsAfter)
-		require.Len(t, voteTargetsAfter, 2) // Only uatom and ueth must be on the vote target
+		require.Len(t, voteTargetsAfter, 2) // Only atom and eth must be on the vote target
 
-		_, err = oracleKeeper.VoteTarget.Get(ctx, utils.MicroKiiDenom)
+		_, err = oracleKeeper.VoteTarget.Get(ctx, utils.KiiDenom)
 		require.Error(t, err)
-		_, err = oracleKeeper.VoteTarget.Get(ctx, utils.MicroUsdcDenom)
+		_, err = oracleKeeper.VoteTarget.Get(ctx, utils.UsdcDenom)
 		require.Error(t, err)
 	})
 }
@@ -259,13 +259,13 @@ func TestOracleDrop(t *testing.T) {
 
 	err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 	require.NoError(t, err)
-	err = input.OracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroAtomDenom, randomAExchangeRate)
+	err = input.OracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, randomAExchangeRate)
 	require.NoError(t, err)
 
 	// Sample exchange rate for the test
-	exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+	exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
 
 	// simulate val 0 votation
 	voteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[0], keeper.ValAddrs[0])
@@ -278,7 +278,7 @@ func TestOracleDrop(t *testing.T) {
 	err = BeginBlocker(ctx, oracleKeeper)
 	require.NoError(t, err)
 
-	exchangeRateRes, err := oracleKeeper.ExchangeRate.Get(ctx, utils.MicroAtomDenom)
+	exchangeRateRes, err := oracleKeeper.ExchangeRate.Get(ctx, utils.AtomDenom)
 	require.NoError(t, err)
 	require.True(t, randomAExchangeRate.Equal(exchangeRateRes.ExchangeRate))
 }
@@ -385,18 +385,18 @@ func TestEndblocker(t *testing.T) {
 		// Aggregate voting targets
 		err = oracleKeeper.VoteTarget.Clear(ctx, nil) // clean voting target list
 		require.NoError(t, err)
-		err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 		require.NoError(t, err)
 
-		err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroEthDenom, types.Denom{Name: utils.MicroEthDenom})
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
 		require.NoError(t, err)
 
 		// Aggregate base exchange rate
-		err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroAtomDenom, math.LegacyNewDec(1))
+		err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, math.LegacyNewDec(1))
 		require.NoError(t, err)
-		err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroEthDenom, math.LegacyNewDec(2))
+		err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.EthDenom, math.LegacyNewDec(2))
 		require.NoError(t, err)
-		err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroKiiDenom, math.LegacyNewDec(3)) // extra denom
+		err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.KiiDenom, math.LegacyNewDec(3)) // extra denom
 		require.NoError(t, err)
 
 		// Execute EndBlocker on the last block of slash window
@@ -409,7 +409,7 @@ func TestEndblocker(t *testing.T) {
 
 		// Validate the successful erased of the extra denoms
 		err = oracleKeeper.ExchangeRate.Walk(ctx, nil, func(denom string, exchangeRate types.OracleExchangeRate) (bool, error) {
-			require.True(t, denom != utils.MicroKiiDenom)
+			require.True(t, denom != utils.KiiDenom)
 			return false, nil
 		})
 		require.NoError(t, err)

--- a/x/oracle/ante_test.go
+++ b/x/oracle/ante_test.go
@@ -82,7 +82,7 @@ func TestSpammingPreventionHandle(t *testing.T) {
 
 	// Create test exchange rate
 	randomAExchangeRate := math.LegacyNewDec(1700)
-	exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+	exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
 
 	voteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[0], keeper.ValAddrs[0])
 	invalidVoteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[5], keeper.ValAddrs[2]) // addr 3 has not been delegated by val 2

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -65,13 +65,13 @@ func CmdAggregateExchangeRateVote() *cobra.Command {
 		Long: strings.TrimSpace(`
 Submit an aggregate vote with the exchange rates.
 
-$kiichaind tx oracle aggregate-vote 123.45akii,678.90uatom...
+$kiichaind tx oracle aggregate-vote 123.45kii,678.90atom...
 
-where "akii,uatom,ueth..." are the denominating currencies and 123.45,678.90 are the exchange rates of micro USD in micro denoms
+where "kii,atom,eth..." are the denominating currencies and 123.45,678.90 are the exchange rates of micro USD in micro denoms
 
 If voting from a delegate account, set "validator" to the address of the validator you are voting on behalf of, i.e:
 
-$ kiichaind oracle aggregate-vote 123.45akii,678.90uatom... kiivaloper1...`),
+$ kiichaind oracle aggregate-vote 123.45kii,678.90atom... kiivaloper1...`),
 		RunE: aggregateVote,
 	}
 

--- a/x/oracle/genesis_test.go
+++ b/x/oracle/genesis_test.go
@@ -20,20 +20,20 @@ func TestExportInitGenesis(t *testing.T) {
 	ctx := input.Ctx
 
 	// Prepare genesis to be exported
-	exchangeRateVote, err := types.NewAggregateExchangeRateVote(types.ExchangeRateTuples{{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(123)}}, keeper.ValAddrs[0])
+	exchangeRateVote, err := types.NewAggregateExchangeRateVote(types.ExchangeRateTuples{{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(123)}}, keeper.ValAddrs[0])
 	require.NoError(t, err)
 
 	snapshot1 := types.NewPriceSnapshot(int64(3600),
 		types.PriceSnapshotItems{
 			{
-				Denom: utils.MicroAtomDenom,
+				Denom: utils.AtomDenom,
 				OracleExchangeRate: types.OracleExchangeRate{
 					ExchangeRate: math.LegacyNewDec(12),
 					LastUpdate:   math.NewInt(3600),
 				},
 			},
 			{
-				Denom: utils.MicroEthDenom,
+				Denom: utils.EthDenom,
 				OracleExchangeRate: types.OracleExchangeRate{
 					ExchangeRate: math.LegacyNewDec(10),
 					LastUpdate:   math.NewInt(3600),
@@ -45,14 +45,14 @@ func TestExportInitGenesis(t *testing.T) {
 	snapshot2 := types.NewPriceSnapshot(int64(3700),
 		types.PriceSnapshotItems{
 			{
-				Denom: utils.MicroAtomDenom,
+				Denom: utils.AtomDenom,
 				OracleExchangeRate: types.OracleExchangeRate{
 					ExchangeRate: math.LegacyNewDec(15),
 					LastUpdate:   math.NewInt(3700),
 				},
 			},
 			{
-				Denom: utils.MicroEthDenom,
+				Denom: utils.EthDenom,
 				OracleExchangeRate: types.OracleExchangeRate{
 					ExchangeRate: math.LegacyNewDec(13),
 					LastUpdate:   math.NewInt(3700),
@@ -63,14 +63,14 @@ func TestExportInitGenesis(t *testing.T) {
 
 	err = oracleKeeper.FeederDelegation.Set(ctx, keeper.ValAddrs[0], keeper.Addrs[1].String())
 	require.NoError(t, err)
-	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroAtomDenom, math.LegacyNewDec(123))
+	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, math.LegacyNewDec(123))
 	require.NoError(t, err)
 	err = oracleKeeper.AggregateExchangeRateVote.Set(ctx, keeper.ValAddrs[0], exchangeRateVote)
 	require.NoError(t, err)
 
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroEthDenom, types.Denom{Name: utils.MicroEthDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
 	require.NoError(t, err)
 
 	err = oracleKeeper.VotePenaltyCounter.Set(ctx, keeper.ValAddrs[0], types.NewVotePenaltyCounter(2, 3, 0))

--- a/x/oracle/keeper/ballot_test.go
+++ b/x/oracle/keeper/ballot_test.go
@@ -43,17 +43,17 @@ func TestOrganizeBallotByDenom(t *testing.T) {
 
 	// Simulate aggregation exchange rate process
 	exchangeRate1 := types.ExchangeRateTuples{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(1)},
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(2)},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(4)},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(1)},
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(2)},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(4)},
 	}
 
 	exchangeRate2 := types.ExchangeRateTuples{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(1)},
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(2)},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(4)},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(1)},
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(2)},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(4)},
 	}
 
 	exchangeRateVote1, err := types.NewAggregateExchangeRateVote(exchangeRate1, ValAddrs[0]) // Aggregate rate tuples from Val0
@@ -92,41 +92,41 @@ func TestOrganizeBallotByDenom(t *testing.T) {
 	}
 
 	// Create expected result (with denom organized alphabetically)
-	uatomBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(1), Power: int64(10), Voter: ValAddrs[0]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(1), Power: int64(10), Voter: ValAddrs[1]},
+	atomBallot := types.ExchangeRateBallot{
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(1), Power: int64(10), Voter: ValAddrs[0]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(1), Power: int64(10), Voter: ValAddrs[1]},
 	}
 
-	uethBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(2), Power: int64(10), Voter: ValAddrs[0]},
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(2), Power: int64(10), Voter: ValAddrs[1]},
+	ethBallot := types.ExchangeRateBallot{
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(2), Power: int64(10), Voter: ValAddrs[0]},
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(2), Power: int64(10), Voter: ValAddrs[1]},
 	}
 
-	uusdcBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(3), Power: int64(10), Voter: ValAddrs[0]},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(3), Power: int64(10), Voter: ValAddrs[1]},
+	usdcBallot := types.ExchangeRateBallot{
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(3), Power: int64(10), Voter: ValAddrs[0]},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(3), Power: int64(10), Voter: ValAddrs[1]},
 	}
 
-	akiiBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(4), Power: int64(10), Voter: ValAddrs[0]},
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(4), Power: int64(10), Voter: ValAddrs[1]},
+	kiiBallot := types.ExchangeRateBallot{
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(4), Power: int64(10), Voter: ValAddrs[0]},
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(4), Power: int64(10), Voter: ValAddrs[1]},
 	}
 
-	sort.Sort(uatomBallot)
-	sort.Sort(uethBallot)
-	sort.Sort(uusdcBallot)
-	sort.Sort(akiiBallot)
+	sort.Sort(atomBallot)
+	sort.Sort(ethBallot)
+	sort.Sort(usdcBallot)
+	sort.Sort(kiiBallot)
 
 	// Call function
 	denomBallot, err := oracleKeeper.OrganizeBallotByDenom(ctx, validatorClaimMap)
 	require.NoError(t, err)
 
 	// Validation
-	microAtomDenomBallot := denomBallot[utils.MicroAtomDenom]
-	require.ElementsMatch(t, uatomBallot, microAtomDenomBallot)
-	require.ElementsMatch(t, uethBallot, denomBallot[utils.MicroEthDenom])
-	require.ElementsMatch(t, uusdcBallot, denomBallot[utils.MicroUsdcDenom])
-	require.ElementsMatch(t, akiiBallot, denomBallot[utils.MicroKiiDenom])
+	atomDenomBallot := denomBallot[utils.AtomDenom]
+	require.ElementsMatch(t, atomBallot, atomDenomBallot)
+	require.ElementsMatch(t, ethBallot, denomBallot[utils.EthDenom])
+	require.ElementsMatch(t, usdcBallot, denomBallot[utils.UsdcDenom])
+	require.ElementsMatch(t, kiiBallot, denomBallot[utils.KiiDenom])
 }
 
 func TestClearBallots(t *testing.T) {
@@ -156,17 +156,17 @@ func TestClearBallots(t *testing.T) {
 
 	// Simulate aggregation exchange rate process
 	exchangeRate1 := types.ExchangeRateTuples{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(1)},
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(2)},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(4)},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(1)},
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(2)},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(4)},
 	}
 
 	exchangeRate2 := types.ExchangeRateTuples{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(1)},
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(2)},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(4)},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(1)},
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(2)},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(3)},
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(4)},
 	}
 
 	exchangeRateVote1, err := types.NewAggregateExchangeRateVote(exchangeRate1, ValAddrs[0]) // Aggregate rate tuples from Val0
@@ -201,27 +201,27 @@ func TestApplyWhitelist(t *testing.T) {
 	err = oracleKeeper.VoteTarget.Clear(ctx, nil) // Delete voting target to start test from scrath
 	require.NoError(t, err)
 
-	// Define new whitelist (adds uusdc)
+	// Define new whitelist (adds usdc)
 	whiteList := types.DenomList{
-		{Name: utils.MicroAtomDenom},
-		{Name: utils.MicroEthDenom},
-		{Name: utils.MicroKiiDenom},
-		{Name: utils.MicroUsdcDenom}, // New Denom
+		{Name: utils.AtomDenom},
+		{Name: utils.EthDenom},
+		{Name: utils.KiiDenom},
+		{Name: utils.UsdcDenom}, // New Denom
 	}
 	oracleParams.Whitelist = whiteList
 	err = oracleKeeper.Params.Set(ctx, oracleParams)
 	require.NoError(t, err)
 
 	// Set vote targets manually before applying the new whitelist
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroEthDenom, types.Denom{Name: utils.MicroEthDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroKiiDenom, types.Denom{Name: utils.MicroKiiDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.KiiDenom, types.Denom{Name: utils.KiiDenom})
 	require.NoError(t, err)
 
-	// Ensure that uusdc is NOT present before applying the whitelist
-	_, err = oracleKeeper.VoteTarget.Get(ctx, utils.MicroUsdcDenom)
+	// Ensure that usdc is NOT present before applying the whitelist
+	_, err = oracleKeeper.VoteTarget.Get(ctx, utils.UsdcDenom)
 	require.Error(t, err)
 
 	// Apply whitelist

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -142,7 +142,7 @@ func TestParams(t *testing.T) {
 	slashFraccion := math.LegacyNewDecWithPrec(1, 2)  // 0.01
 	slashwindow := uint64(1000)
 	minValPerWindow := math.LegacyNewDecWithPrec(1, 4) // 0.0001
-	whiteList := types.DenomList{{Name: utils.MicroKiiDenom}, {Name: utils.MicroAtomDenom}}
+	whiteList := types.DenomList{{Name: utils.KiiDenom}, {Name: utils.AtomDenom}}
 	lookbackDuration := uint64(3600)
 
 	params := types.Params{
@@ -351,17 +351,17 @@ func TestRemoveExcessFeeds(t *testing.T) {
 	// Aggregate voting targets
 	err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroEthDenom, types.Denom{Name: utils.MicroEthDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
 	require.NoError(t, err)
 
 	// Aggregate base exchange rate
-	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroAtomDenom, math.LegacyNewDec(1))
+	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, math.LegacyNewDec(1))
 	require.NoError(t, err)
-	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroEthDenom, math.LegacyNewDec(2))
+	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.EthDenom, math.LegacyNewDec(2))
 	require.NoError(t, err)
-	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroKiiDenom, math.LegacyNewDec(3)) // extra denom
+	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.KiiDenom, math.LegacyNewDec(3)) // extra denom
 	require.NoError(t, err)
 
 	// remove excess
@@ -370,7 +370,7 @@ func TestRemoveExcessFeeds(t *testing.T) {
 
 	// Validate the successful erased of the extra denoms
 	err = oracleKeeper.ExchangeRate.Walk(ctx, nil, func(denom string, exchangeRate types.OracleExchangeRate) (bool, error) {
-		require.True(t, denom != utils.MicroKiiDenom)
+		require.True(t, denom != utils.KiiDenom)
 		return false, nil
 	})
 	require.NoError(t, err)
@@ -386,10 +386,10 @@ func TestVoteTargetLogic(t *testing.T) {
 	err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 	require.NoError(t, err)
 	voteTarget := map[string]types.Denom{
-		utils.MicroKiiDenom:  {Name: utils.MicroKiiDenom},
-		utils.MicroEthDenom:  {Name: utils.MicroEthDenom},
-		utils.MicroUsdcDenom: {Name: utils.MicroUsdcDenom},
-		utils.MicroAtomDenom: {Name: utils.MicroAtomDenom},
+		utils.KiiDenom:  {Name: utils.KiiDenom},
+		utils.EthDenom:  {Name: utils.EthDenom},
+		utils.UsdcDenom: {Name: utils.UsdcDenom},
+		utils.AtomDenom: {Name: utils.AtomDenom},
 	}
 
 	for denom := range voteTarget {
@@ -434,8 +434,8 @@ func TestPriceSnapshotLogic(t *testing.T) {
 		LastUpdate:          math.NewInt(2),
 		LastUpdateTimestamp: 2,
 	}
-	snapshotItem1 := types.NewPriceSnapshotItem(utils.MicroKiiDenom, exchangeRate1)
-	snapshotItem2 := types.NewPriceSnapshotItem(utils.MicroEthDenom, exchangeRate2)
+	snapshotItem1 := types.NewPriceSnapshotItem(utils.KiiDenom, exchangeRate1)
+	snapshotItem2 := types.NewPriceSnapshotItem(utils.EthDenom, exchangeRate2)
 	snapshot1 := types.NewPriceSnapshot(1, types.PriceSnapshotItems{snapshotItem1, snapshotItem1})
 	snapshot2 := types.NewPriceSnapshot(2, types.PriceSnapshotItems{snapshotItem2, snapshotItem2})
 
@@ -498,8 +498,8 @@ func TestAddPriceSnapshot(t *testing.T) {
 		LastUpdate:          math.NewInt(2),
 		LastUpdateTimestamp: 2,
 	}
-	snapshotItem1 := types.NewPriceSnapshotItem(utils.MicroKiiDenom, exchangeRate1)
-	snapshotItem2 := types.NewPriceSnapshotItem(utils.MicroEthDenom, exchangeRate2)
+	snapshotItem1 := types.NewPriceSnapshotItem(utils.KiiDenom, exchangeRate1)
+	snapshotItem2 := types.NewPriceSnapshotItem(utils.EthDenom, exchangeRate2)
 	snapshot1 := types.NewPriceSnapshot(1, types.PriceSnapshotItems{snapshotItem1, snapshotItem2})
 	snapshot2 := types.NewPriceSnapshot(2, types.PriceSnapshotItems{snapshotItem1, snapshotItem2})
 
@@ -526,7 +526,7 @@ func TestAddPriceSnapshot(t *testing.T) {
 		LastUpdate:          math.NewInt(4),
 		LastUpdateTimestamp: 3,
 	}
-	snapshotItem3 := types.NewPriceSnapshotItem(utils.MicroKiiDenom, exchangeRate3)
+	snapshotItem3 := types.NewPriceSnapshotItem(utils.KiiDenom, exchangeRate3)
 	snapshot3 := types.NewPriceSnapshot(1000, types.PriceSnapshotItems{snapshotItem1, snapshotItem2, snapshotItem3})
 
 	// Add snapshots (the function will delete the snapshot 1 and 2)
@@ -558,9 +558,9 @@ func TestClearVoteTargets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Aggregate voting targets
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroEthDenom, types.Denom{Name: utils.MicroEthDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
 	require.NoError(t, err)
 
 	// Validate the voting target were successfully added

--- a/x/oracle/keeper/msg_server_test.go
+++ b/x/oracle/keeper/msg_server_test.go
@@ -38,7 +38,7 @@ func TestAggregateExchangeRateVote(t *testing.T) {
 	require.NoError(t, err)
 
 	// send messages
-	exchangeRate := math.LegacyNewDec(12).String() + utils.MicroUsdcDenom
+	exchangeRate := math.LegacyNewDec(12).String() + utils.UsdcDenom
 	_, err = msgServer.AggregateExchangeRateVote(ctx, types.NewMsgAggregateExchangeRateVote(exchangeRate, Addrs[0], ValAddrs[0]))
 
 	// validation

--- a/x/oracle/keeper/query_server_test.go
+++ b/x/oracle/keeper/query_server_test.go
@@ -41,10 +41,10 @@ func TestQueryExchangeRate(t *testing.T) {
 
 	// insert data on the module
 	rate := math.LegacyNewDec(12)
-	err := oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroAtomDenom, rate)
+	err := oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, rate)
 	require.NoError(t, err)
 	// query params
-	res, err := querier.ExchangeRate(ctx, &types.QueryExchangeRateRequest{Denom: utils.MicroAtomDenom})
+	res, err := querier.ExchangeRate(ctx, &types.QueryExchangeRateRequest{Denom: utils.AtomDenom})
 
 	// validation
 	require.NoError(t, err)
@@ -62,9 +62,9 @@ func TestQueryExchangeRates(t *testing.T) {
 
 	// insert data on the module
 	rate := math.LegacyNewDec(12)
-	err := oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroAtomDenom, rate)
+	err := oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, rate)
 	require.NoError(t, err)
-	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroEthDenom, rate)
+	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.EthDenom, rate)
 	require.NoError(t, err)
 
 	// query params
@@ -86,9 +86,9 @@ func TestQueryActives(t *testing.T) {
 
 	// insert data on the module
 	rate := math.LegacyNewDec(12)
-	err := oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroAtomDenom, rate)
+	err := oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, rate)
 	require.NoError(t, err)
-	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.MicroEthDenom, rate)
+	err = oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.EthDenom, rate)
 	require.NoError(t, err)
 
 	// query params
@@ -97,8 +97,8 @@ func TestQueryActives(t *testing.T) {
 	// validation
 	require.NoError(t, err)
 	require.Equal(t, 2, len(res.Actives))
-	require.Equal(t, utils.MicroAtomDenom, res.Actives[0])
-	require.Equal(t, utils.MicroEthDenom, res.Actives[1])
+	require.Equal(t, utils.AtomDenom, res.Actives[0])
+	require.Equal(t, utils.EthDenom, res.Actives[1])
 }
 
 func TestQueryVoteTargets(t *testing.T) {
@@ -113,9 +113,9 @@ func TestQueryVoteTargets(t *testing.T) {
 	// insert data on the module
 	err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroAtomDenom, types.Denom{Name: utils.MicroAtomDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
 	require.NoError(t, err)
-	err = oracleKeeper.VoteTarget.Set(ctx, utils.MicroEthDenom, types.Denom{Name: utils.MicroEthDenom})
+	err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
 	require.NoError(t, err)
 
 	// query params
@@ -124,8 +124,8 @@ func TestQueryVoteTargets(t *testing.T) {
 	// validation
 	require.NoError(t, err)
 	require.Equal(t, 2, len(res.VoteTargets))
-	require.Equal(t, utils.MicroAtomDenom, res.VoteTargets[0])
-	require.Equal(t, utils.MicroEthDenom, res.VoteTargets[1])
+	require.Equal(t, utils.AtomDenom, res.VoteTargets[0])
+	require.Equal(t, utils.EthDenom, res.VoteTargets[1])
 }
 
 func TestQueryPriceSnapshotHistory(t *testing.T) {
@@ -139,22 +139,22 @@ func TestQueryPriceSnapshotHistory(t *testing.T) {
 
 	// insert data on the module
 	snapShot1 := types.NewPriceSnapshot(1, types.PriceSnapshotItems{
-		types.NewPriceSnapshotItem(utils.MicroEthDenom, types.OracleExchangeRate{
+		types.NewPriceSnapshotItem(utils.EthDenom, types.OracleExchangeRate{
 			ExchangeRate: math.LegacyNewDec(11),
 			LastUpdate:   math.NewInt(20),
 		}),
-		types.NewPriceSnapshotItem(utils.MicroAtomDenom, types.OracleExchangeRate{
+		types.NewPriceSnapshotItem(utils.AtomDenom, types.OracleExchangeRate{
 			ExchangeRate: math.LegacyNewDec(12),
 			LastUpdate:   math.NewInt(20),
 		}),
 	})
 
 	snapShot2 := types.NewPriceSnapshot(2, types.PriceSnapshotItems{
-		types.NewPriceSnapshotItem(utils.MicroEthDenom, types.OracleExchangeRate{
+		types.NewPriceSnapshotItem(utils.EthDenom, types.OracleExchangeRate{
 			ExchangeRate: math.LegacyNewDec(21),
 			LastUpdate:   math.NewInt(30),
 		}),
-		types.NewPriceSnapshotItem(utils.MicroAtomDenom, types.OracleExchangeRate{
+		types.NewPriceSnapshotItem(utils.AtomDenom, types.OracleExchangeRate{
 			ExchangeRate: math.LegacyNewDec(22),
 			LastUpdate:   math.NewInt(30),
 		}),
@@ -195,8 +195,8 @@ func TestQueryTwaps(t *testing.T) {
 		LastUpdate:          math.NewInt(2),
 		LastUpdateTimestamp: 2,
 	}
-	snapshotItem1 := types.NewPriceSnapshotItem(utils.MicroKiiDenom, exchangeRate1)
-	snapshotItem2 := types.NewPriceSnapshotItem(utils.MicroEthDenom, exchangeRate2)
+	snapshotItem1 := types.NewPriceSnapshotItem(utils.KiiDenom, exchangeRate1)
+	snapshotItem2 := types.NewPriceSnapshotItem(utils.EthDenom, exchangeRate2)
 	snapshot1 := types.NewPriceSnapshot(1, types.PriceSnapshotItems{snapshotItem1, snapshotItem1})
 	snapshot2 := types.NewPriceSnapshot(2, types.PriceSnapshotItems{snapshotItem2, snapshotItem2})
 
@@ -219,7 +219,7 @@ func TestQueryTwaps(t *testing.T) {
 
 	// validation
 	require.NoError(t, err)
-	require.Equal(t, utils.MicroEthDenom, res.OracleTwap[0].Denom)
+	require.Equal(t, utils.EthDenom, res.OracleTwap[0].Denom)
 	require.Equal(t, math.LegacyNewDec(2), res.OracleTwap[0].Twap)
 }
 

--- a/x/oracle/keeper/test_utils.go
+++ b/x/oracle/keeper/test_utils.go
@@ -67,8 +67,8 @@ const faucetAccountName = "faucet"
 
 var (
 	InitTokens   = sdk.TokensFromConsensusPower(200, sdk.DefaultPowerReduction)
-	InitialCoins = sdk.NewCoins(sdk.NewCoin(utils.MicroKiiDenom, InitTokens))
-	kiiCoins     = sdk.NewCoins(sdk.NewCoin(utils.MicroKiiDenom, InitTokens.MulRaw(int64(len(Addrs)+2))))
+	InitialCoins = sdk.NewCoins(sdk.NewCoin(utils.KiiDenom, InitTokens))
+	kiiCoins     = sdk.NewCoins(sdk.NewCoin(utils.KiiDenom, InitTokens.MulRaw(int64(len(Addrs)+2))))
 
 	OracleDecPrecision = 8
 
@@ -220,7 +220,7 @@ func CreateTestInput(t *testing.T) TestInput {
 		authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
 	)
 	stakingParams := stakingtypes.DefaultParams()
-	stakingParams.BondDenom = utils.MicroKiiDenom
+	stakingParams.BondDenom = utils.KiiDenom
 	err := stakingKeeper.SetParams(ctx, stakingParams)
 	require.NoError(t, err)
 
@@ -249,11 +249,11 @@ func CreateTestInput(t *testing.T) TestInput {
 	require.NoError(t, err) // Validate the operation
 
 	// Verify the faucet balance
-	balance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(faucetAccountName), utils.MicroKiiDenom)
+	balance := bankKeeper.GetBalance(ctx, accountKeeper.GetModuleAddress(faucetAccountName), utils.KiiDenom)
 	require.True(t, balance.IsGTE(kiiCoins[0]), "Faucet account does not have enough funds")
 
 	// Send some tokens to not_bonded_tokens_pool account
-	err = bankKeeper.SendCoinsFromModuleToModule(ctx, faucetAccountName, stakingtypes.NotBondedPoolName, sdk.NewCoins(sdk.NewCoin(utils.MicroKiiDenom, math.NewInt(100))))
+	err = bankKeeper.SendCoinsFromModuleToModule(ctx, faucetAccountName, stakingtypes.NotBondedPoolName, sdk.NewCoins(sdk.NewCoin(utils.KiiDenom, math.NewInt(100))))
 	require.NoError(t, err) // Validate the operation
 
 	// Send initial funds to testing accounts
@@ -299,7 +299,7 @@ func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey cryptotypes.PubKey
 	// Get the validator rates (0.05)
 	rate := math.LegacyNewDecWithPrec(5, 2)
 	// Build the self delegation
-	selfDelegation := sdk.NewCoin(utils.MicroKiiDenom, amount)
+	selfDelegation := sdk.NewCoin(utils.KiiDenom, amount)
 	// Build the commission rates
 	commission := stakingtypes.NewCommissionRates(rate, rate, rate)
 

--- a/x/oracle/keeper/vote_target_test.go
+++ b/x/oracle/keeper/vote_target_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kiichain/kiichain/v5/x/oracle/types"
+	"github.com/kiichain/kiichain/v5/x/oracle/utils"
 )
 
 func TestGetVoteTargets(t *testing.T) {
@@ -18,7 +19,7 @@ func TestGetVoteTargets(t *testing.T) {
 	require.NoError(t, err)
 
 	// set new expected targets
-	expectedTargets := []string{"akii", "ubtc", "ueth"}
+	expectedTargets := []string{utils.KiiDenom, utils.BtcDenom, utils.EthDenom}
 	for _, target := range expectedTargets {
 		err = oracleKeeper.VoteTarget.Set(input.Ctx, target, types.Denom{Name: target})
 		require.NoError(t, err)
@@ -49,7 +50,7 @@ func TestIsVoteTarget(t *testing.T) {
 	require.NoError(t, err)
 
 	// set new expected targets and validate
-	validTargets := []string{"akii", "ubtc", "ueth"}
+	validTargets := []string{utils.KiiDenom, utils.BtcDenom, utils.EthDenom}
 	for _, target := range validTargets {
 		err = oracleKeeper.VoteTarget.Set(input.Ctx, target, types.Denom{Name: target})
 		require.NoError(t, err)

--- a/x/oracle/tally_test.go
+++ b/x/oracle/tally_test.go
@@ -50,73 +50,73 @@ func TestPickReferenceDenom(t *testing.T) {
 
 	// Create voting targets
 	votingTarget := map[string]types.Denom{
-		utils.MicroAtomDenom: {Name: utils.MicroAtomDenom},
-		utils.MicroEthDenom:  {Name: utils.MicroEthDenom},
-		utils.MicroUsdcDenom: {Name: utils.MicroUsdcDenom},
-		utils.MicroKiiDenom:  {Name: utils.MicroKiiDenom},
+		utils.AtomDenom: {Name: utils.AtomDenom},
+		utils.EthDenom:  {Name: utils.EthDenom},
+		utils.UsdcDenom: {Name: utils.UsdcDenom},
+		utils.KiiDenom:  {Name: utils.KiiDenom},
 	}
 
 	// Create vote map (the voting (ballot) per denom)
-	uatomBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4000), Power: int64(20), Voter: keeper.ValAddrs[0]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4100), Power: int64(10), Voter: keeper.ValAddrs[1]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4200), Power: int64(30), Voter: keeper.ValAddrs[3]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(5000), Power: int64(30), Voter: keeper.ValAddrs[4]},
+	atomBallot := types.ExchangeRateBallot{
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4000), Power: int64(20), Voter: keeper.ValAddrs[0]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4100), Power: int64(10), Voter: keeper.ValAddrs[1]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4200), Power: int64(30), Voter: keeper.ValAddrs[3]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(5000), Power: int64(30), Voter: keeper.ValAddrs[4]},
 	}
 
-	uethBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(10000), Power: int64(20), Voter: keeper.ValAddrs[0]},
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(9580), Power: int64(30), Voter: keeper.ValAddrs[3]},
-		{Denom: utils.MicroEthDenom, ExchangeRate: math.LegacyNewDec(10300), Power: int64(30), Voter: keeper.ValAddrs[4]},
+	ethBallot := types.ExchangeRateBallot{
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(10000), Power: int64(20), Voter: keeper.ValAddrs[0]},
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(9580), Power: int64(30), Voter: keeper.ValAddrs[3]},
+		{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDec(10300), Power: int64(30), Voter: keeper.ValAddrs[4]},
 	}
 
-	uusdcBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(20000), Power: int64(20), Voter: keeper.ValAddrs[0]},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(20100), Power: int64(10), Voter: keeper.ValAddrs[1]},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(19580), Power: int64(30), Voter: keeper.ValAddrs[3]},
-		{Denom: utils.MicroUsdcDenom, ExchangeRate: math.LegacyNewDec(20300), Power: int64(30), Voter: keeper.ValAddrs[4]},
+	usdcBallot := types.ExchangeRateBallot{
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(20000), Power: int64(20), Voter: keeper.ValAddrs[0]},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(20100), Power: int64(10), Voter: keeper.ValAddrs[1]},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(19580), Power: int64(30), Voter: keeper.ValAddrs[3]},
+		{Denom: utils.UsdcDenom, ExchangeRate: math.LegacyNewDec(20300), Power: int64(30), Voter: keeper.ValAddrs[4]},
 	}
 
-	akiiBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(30000), Power: int64(20), Voter: keeper.ValAddrs[0]},
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(30100), Power: int64(10), Voter: keeper.ValAddrs[1]},
-		{Denom: utils.MicroKiiDenom, ExchangeRate: math.LegacyNewDec(29580), Power: int64(30), Voter: keeper.ValAddrs[3]},
+	kiiBallot := types.ExchangeRateBallot{
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(30000), Power: int64(20), Voter: keeper.ValAddrs[0]},
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(30100), Power: int64(10), Voter: keeper.ValAddrs[1]},
+		{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDec(29580), Power: int64(30), Voter: keeper.ValAddrs[3]},
 	}
 
 	voteMap := map[string]types.ExchangeRateBallot{
-		utils.MicroAtomDenom: uatomBallot,
-		utils.MicroEthDenom:  uethBallot,
-		utils.MicroUsdcDenom: uusdcBallot,
-		utils.MicroKiiDenom:  akiiBallot,
-		"extraDenom":         uatomBallot, // This denom will be removed because is not on the voting targets
+		utils.AtomDenom: atomBallot,
+		utils.EthDenom:  ethBallot,
+		utils.UsdcDenom: usdcBallot,
+		utils.KiiDenom:  kiiBallot,
+		"extraDenom":    atomBallot, // This denom will be removed because is not on the voting targets
 	}
 
 	// Expected below threshold vote map
 	expectedBelowThreshold := map[string]types.ExchangeRateBallot{
-		utils.MicroKiiDenom: akiiBallot,
+		utils.KiiDenom: kiiBallot,
 	}
 
-	// Must return denom MicroAtomDenom and akiiBallot as below threshold map
+	// Must return denom atomDenom and kiiBallot as below threshold map
 	referenceDenom, belowThresholdVoteMap := pickReferenceDenom(ctx, oracleKeeper, votingTarget, voteMap)
-	require.Equal(t, utils.MicroAtomDenom, referenceDenom)
+	require.Equal(t, utils.AtomDenom, referenceDenom)
 	require.Equal(t, expectedBelowThreshold, belowThresholdVoteMap)
 }
 
 func TestBallotIsPassing(t *testing.T) {
-	uatomBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4000), Power: int64(20), Voter: keeper.ValAddrs[0]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4100), Power: int64(10), Voter: keeper.ValAddrs[1]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4200), Power: int64(30), Voter: keeper.ValAddrs[3]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(5000), Power: int64(30), Voter: keeper.ValAddrs[4]},
+	atomBallot := types.ExchangeRateBallot{
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4000), Power: int64(20), Voter: keeper.ValAddrs[0]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4100), Power: int64(10), Voter: keeper.ValAddrs[1]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4200), Power: int64(30), Voter: keeper.ValAddrs[3]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(5000), Power: int64(30), Voter: keeper.ValAddrs[4]},
 	}
 
 	// must return true because the threshold is lower than the ballot power
-	power, ispassing := ballotIsPassing(uatomBallot, math.NewInt(80))
+	power, ispassing := ballotIsPassing(atomBallot, math.NewInt(80))
 	require.Equal(t, math.NewInt(90), power)
 	require.True(t, ispassing)
 
 	// must return false because the threshold is higher than the ballot power
-	power, ispassing = ballotIsPassing(uatomBallot, math.NewInt(100))
+	power, ispassing = ballotIsPassing(atomBallot, math.NewInt(100))
 	require.Equal(t, math.NewInt(90), power)
 	require.False(t, ispassing)
 }
@@ -167,11 +167,11 @@ func TestTally(t *testing.T) {
 		validatorClaimMap[operator] = claim // Assign the validator on the list to receive
 	}
 
-	uatomBallot := types.ExchangeRateBallot{
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4160), Power: int64(10), Voter: keeper.ValAddrs[0]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4180), Power: int64(20), Voter: keeper.ValAddrs[1]},
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(4200), Power: int64(30), Voter: keeper.ValAddrs[2]}, // weighted median
-		{Denom: utils.MicroAtomDenom, ExchangeRate: math.LegacyNewDec(5000), Power: int64(40), Voter: keeper.ValAddrs[3]},
+	atomBallot := types.ExchangeRateBallot{
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4160), Power: int64(10), Voter: keeper.ValAddrs[0]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4180), Power: int64(20), Voter: keeper.ValAddrs[1]},
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(4200), Power: int64(30), Voter: keeper.ValAddrs[2]}, // weighted median
+		{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDec(5000), Power: int64(40), Voter: keeper.ValAddrs[3]},
 	}
 
 	// median = 4200
@@ -181,7 +181,7 @@ func TestTally(t *testing.T) {
 	// upper limit = 4242
 	// lower limit = 4158
 
-	weightedMedian := Tally(ctx, uatomBallot, math.LegacyNewDecWithPrec(2, 2), validatorClaimMap)
+	weightedMedian := Tally(ctx, atomBallot, math.LegacyNewDecWithPrec(2, 2), validatorClaimMap)
 	require.Equal(t, math.LegacyNewDec(4200), weightedMedian)
 
 	// validate validators who voted

--- a/x/oracle/types/ballot_test.go
+++ b/x/oracle/types/ballot_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	ChainDenom = "akii"
-	UUSDC      = "uusdc"
+	USDC       = "usdc"
 )
 
 func TestNewClaim(t *testing.T) {
@@ -185,7 +185,7 @@ func TestStandardDeviation(t *testing.T) {
 func TestToCrossRate(t *testing.T) {
 	// Create exchangeRate ballot (reference and other)
 	denom := ChainDenom
-	denomRefernce := UUSDC
+	denomRefernce := USDC
 	voter1 := sdk.ValAddress([]byte("validator1"))
 	voter2 := sdk.ValAddress([]byte("validator2"))
 	voter3 := sdk.ValAddress([]byte("validator3"))
@@ -225,7 +225,7 @@ func TestToCrossRate(t *testing.T) {
 func TestToCrossRateNotFound(t *testing.T) {
 	// Create exchangeRate ballot (reference and other)
 	denom := ChainDenom
-	denomRefernce := UUSDC
+	denomRefernce := USDC
 	voter1 := sdk.ValAddress([]byte("validator1"))
 	voter2 := sdk.ValAddress([]byte("validator2"))
 	voter3 := sdk.ValAddress([]byte("validator3"))
@@ -263,7 +263,7 @@ func TestToCrossRateNotFound(t *testing.T) {
 func TestToCrossRateWithSort(t *testing.T) {
 	// Create exchangeRate ballot (reference and other)
 	denom := ChainDenom
-	denomRefernce := UUSDC
+	denomRefernce := USDC
 	voter1 := sdk.ValAddress([]byte("validator1"))
 	voter2 := sdk.ValAddress([]byte("validator2"))
 	voter3 := sdk.ValAddress([]byte("validator3"))

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -17,14 +17,14 @@ var (
 	DefaultVoteThreshold = math.LegacyNewDecWithPrec(667, 3) // 0.667 | 66.7%
 	DefaultRewardBand    = math.LegacyNewDecWithPrec(2, 2)   // 0.02% | 2%
 	DefaultWhitelist     = DenomList{
-		{Name: utils.MicroBtcDenom},
-		{Name: utils.MicroEthDenom},
-		{Name: utils.MicroSolDenom},
-		{Name: utils.MicroXrpDenom},
-		{Name: utils.MicroBnbDenom},
-		{Name: utils.MicroUsdtDenom},
-		{Name: utils.MicroUsdcDenom},
-		{Name: utils.MicroTrxDenom},
+		{Name: utils.BtcDenom},
+		{Name: utils.EthDenom},
+		{Name: utils.SolDenom},
+		{Name: utils.XrpDenom},
+		{Name: utils.BnbDenom},
+		{Name: utils.UsdtDenom},
+		{Name: utils.UsdcDenom},
+		{Name: utils.TrxDenom},
 	}
 	DefaultSlashFraction     = math.LegacyNewDecWithPrec(0, 4) // 0.00 | 0%
 	DefaultMinValidPerWindow = math.LegacyNewDecWithPrec(5, 2) // 0.05 | 5%

--- a/x/oracle/types/snapshots_test.go
+++ b/x/oracle/types/snapshots_test.go
@@ -20,7 +20,7 @@ func TestNewPriceSnapshotItem(t *testing.T) {
 
 	// expected result
 	expected := PriceSnapshotItem{
-		Denom: utils.MicroAtomDenom,
+		Denom: utils.AtomDenom,
 		OracleExchangeRate: OracleExchangeRate{
 			ExchangeRate:        math.LegacyNewDec(11),
 			LastUpdate:          math.NewInt(10),
@@ -29,7 +29,7 @@ func TestNewPriceSnapshotItem(t *testing.T) {
 	}
 
 	// create snapshot item
-	item := NewPriceSnapshotItem(utils.MicroAtomDenom, rate)
+	item := NewPriceSnapshotItem(utils.AtomDenom, rate)
 
 	// validate
 	require.Equal(t, expected, item)
@@ -42,7 +42,7 @@ func TestNewPriceSnapshot(t *testing.T) {
 		LastUpdate:          math.NewInt(10),
 		LastUpdateTimestamp: time.Now().Unix(),
 	}
-	item1 := NewPriceSnapshotItem(utils.MicroAtomDenom, rate1)
+	item1 := NewPriceSnapshotItem(utils.AtomDenom, rate1)
 
 	// price item 2
 	rate2 := OracleExchangeRate{
@@ -50,7 +50,7 @@ func TestNewPriceSnapshot(t *testing.T) {
 		LastUpdate:          math.NewInt(10),
 		LastUpdateTimestamp: time.Now().Unix(),
 	}
-	item2 := NewPriceSnapshotItem(utils.MicroEthDenom, rate2)
+	item2 := NewPriceSnapshotItem(utils.EthDenom, rate2)
 
 	// create snapshot
 	items := PriceSnapshotItems{item1, item2}
@@ -61,7 +61,7 @@ func TestNewPriceSnapshot(t *testing.T) {
 		SnapshotTimestamp: 12,
 		PriceSnapshotItems: PriceSnapshotItems{
 			PriceSnapshotItem{
-				Denom: utils.MicroAtomDenom,
+				Denom: utils.AtomDenom,
 				OracleExchangeRate: OracleExchangeRate{
 					ExchangeRate:        math.LegacyNewDec(11),
 					LastUpdate:          math.NewInt(10),
@@ -70,7 +70,7 @@ func TestNewPriceSnapshot(t *testing.T) {
 			},
 
 			PriceSnapshotItem{
-				Denom: utils.MicroEthDenom,
+				Denom: utils.EthDenom,
 				OracleExchangeRate: OracleExchangeRate{
 					ExchangeRate:        math.LegacyNewDec(22),
 					LastUpdate:          math.NewInt(10),

--- a/x/oracle/utils/assets.go
+++ b/x/oracle/utils/assets.go
@@ -1,14 +1,14 @@
 package utils
 
 const (
-	MicroUsdcDenom = "uusdc"
-	MicroKiiDenom  = "akii"
-	MicroAtomDenom = "uatom"
-	MicroEthDenom  = "ueth"
-	MicroBtcDenom  = "ubtc"
-	MicroSolDenom  = "usol"
-	MicroXrpDenom  = "uxrp"
-	MicroBnbDenom  = "ubnb"
-	MicroUsdtDenom = "uusdt"
-	MicroTrxDenom  = "utrx"
+	UsdcDenom = "usdc"
+	KiiDenom  = "kii"
+	AtomDenom = "atom"
+	EthDenom  = "eth"
+	BtcDenom  = "btc"
+	SolDenom  = "sol"
+	XrpDenom  = "xrp"
+	BnbDenom  = "bnb"
+	UsdtDenom = "usdt"
+	TrxDenom  = "trx"
 )


### PR DESCRIPTION
# Description

Swap micro coins denom on oracles for non-micro ones. Since we only care about the ratio, we don't need to confuse with micro denoms.

## Type of change
- [x] Documentation (updates documentation on the project)


# How Has This Been Tested?
`make test-unit` and `make test-e2e`
