### PR TITLE
Fix reentrance problems on the Wasmd precompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,32 @@
 # CHANGELOG
 
-## UNRELEASED
-
-
-## DEPENDENCIES
-- Bump [cosmos-sdk](https://github.com/cosmos/cosmos-sdk) to [v0.53.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.4)
-- Bump [Wasmd](https://github.com/CosmWasm/wasmd) to [v0.61.2](https://github.com/CosmWasm/wasmd/releases/tag/v0.61.2)
-- Bump [EVM](github.com/cosmos/evm) to [v0.4.1](https://github.com/cosmos/evm/releases/tag/v0.4.1)
-- Bump [IBC-go](https://github.com/cosmos/ibc-go/) to [v10.3.0](https://github.com/cosmos/ibc-go/releases/tag/v10.3.0)
-- Removed crisis module 
+## v5.1.0 — 2025-10-15
 
 ### Fixes
 
-- Add missing address validation in `GetTokenfactoryDenomsByCreator` query to prevent potential crashes with malformed addresses
-- Override EVM chain ID if default
-- Change evm chain coin info mapping to always default
+-   Fix wasmd precompile against reentrance attacks
+
+## v5.0.0 — 2025-09-26
+
+## DEPENDENCIES
+
+-   Bump [cosmos-sdk](https://github.com/cosmos/cosmos-sdk) to [v0.53.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.4)
+-   Bump [Wasmd](https://github.com/CosmWasm/wasmd) to [v0.61.2](https://github.com/CosmWasm/wasmd/releases/tag/v0.61.2)
+-   Bump [EVM](github.com/cosmos/evm) to [v0.4.1](https://github.com/cosmos/evm/releases/tag/v0.4.1)
+-   Bump [IBC-go](https://github.com/cosmos/ibc-go/) to [v10.3.0](https://github.com/cosmos/ibc-go/releases/tag/v10.3.0)
+-   Removed crisis module
+
+### Fixes
+
+-   Add missing address validation in `GetTokenfactoryDenomsByCreator` query to prevent potential crashes with malformed addresses
+-   Override EVM chain ID if default
+-   Change evm chain coin info mapping to always default
 
 ## v4.0.0 — 2025-08-06
 
 ### Added
 
-- Add the fee abstraction module to the chain
+-   Add the fee abstraction module to the chain
 
 ## v3.0.0 — 2025-07-01
 
@@ -30,25 +36,25 @@ No changes were made since the release candidate.
 
 ### Added
 
-- Add the oracle module to the chain
-- Add the oracle wasmbinding
-- Add the oracle EMV precompile
-- Add E2E tests to IBC precompile
-- Add E2E tests to wasmd precompile
+-   Add the oracle module to the chain
+-   Add the oracle wasmbinding
+-   Add the oracle EMV precompile
+-   Add E2E tests to IBC precompile
+-   Add E2E tests to wasmd precompile
 
 ## v2.0.0 -- 2025-06-18
 
 ### Added
 
-- Initial chain creation
-- Add EVM wasmbinding queries
-- Add bech32 wasmbinding queries
-- Add IBC precompile to transfer via EVM
-- Add correct ibc keepers to ibc precompiles
-- Add Rewards module
+-   Initial chain creation
+-   Add EVM wasmbinding queries
+-   Add bech32 wasmbinding queries
+-   Add IBC precompile to transfer via EVM
+-   Add correct ibc keepers to ibc precompiles
+-   Add Rewards module
 
 ### Changed
 
-- Update pipelines by adding codeql, codecov and changelog diff checker
-- Refactor the tokenfactory wasmbinding into its own path
-- Refactor the wasmbinding implementation to allow multiple msg and query types
+-   Update pipelines by adding codeql, codecov and changelog diff checker
+-   Refactor the tokenfactory wasmbinding into its own path
+-   Refactor the wasmbinding implementation to allow multiple msg and query types

--- a/app/app.go
+++ b/app/app.go
@@ -67,7 +67,7 @@ import (
 	kiiante "github.com/kiichain/kiichain/v5/ante"
 	"github.com/kiichain/kiichain/v5/app/keepers"
 	"github.com/kiichain/kiichain/v5/app/upgrades"
-	v5_0 "github.com/kiichain/kiichain/v5/app/upgrades/v5_0"
+	v5_1 "github.com/kiichain/kiichain/v5/app/upgrades/v5_1"
 	"github.com/kiichain/kiichain/v5/client/docs"
 )
 
@@ -77,7 +77,7 @@ var (
 
 	// Upgrades is a list of all the upgrades that are available for the application.
 	Upgrades = []upgrades.Upgrade{
-		v5_0.Upgrade,
+		v5_1.Upgrade,
 	}
 )
 

--- a/app/upgrades/v5_1/constants.go
+++ b/app/upgrades/v5_1/constants.go
@@ -1,0 +1,16 @@
+package v510
+
+import (
+	"github.com/kiichain/kiichain/v5/app/upgrades"
+)
+
+const (
+	// UpgradeName is the name of the upgrade
+	UpgradeName = "v5.1.0"
+)
+
+// Upgrade defines the upgrade, nothing is done here
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: nil,
+}

--- a/app/upgrades/v5_1/constants.go
+++ b/app/upgrades/v5_1/constants.go
@@ -12,5 +12,5 @@ const (
 // Upgrade defines the upgrade, nothing is done here
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
-	CreateUpgradeHandler: nil,
+	CreateUpgradeHandler: CreateUpgradeHandler,
 }

--- a/app/upgrades/v5_1/upgrade.go
+++ b/app/upgrades/v5_1/upgrade.go
@@ -1,0 +1,36 @@
+package v510
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/kiichain/kiichain/v5/app/keepers"
+)
+
+// CreateUpgradeHandler creates the upgrade handler for the v5.1.0 upgrade
+// Its only purpose is to run the module migrations
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(c context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		// State the context and log
+		ctx := sdk.UnwrapSDKContext(c)
+		ctx.Logger().Info("Starting module migrations...")
+
+		// Run the module migrations, it will start the new module with it's init genesis
+		vm, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return vm, err
+		}
+
+		// Log the upgrade completion
+		ctx.Logger().Info("Upgrade v5.1.0 complete")
+		return vm, nil
+	}
+}

--- a/precompiles/wasmd/realworld_attack_test.go
+++ b/precompiles/wasmd/realworld_attack_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 
 	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/cosmos/evm/precompiles/testutil"
@@ -60,8 +61,8 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
 		attackAttempts := 5
 		successfulReentries := 0
 
+		stateDB := s.GetStateDB()
 		for attempt := 1; attempt <= attackAttempts; attempt++ {
-			stateDB := s.GetStateDB()
 			contract, ctx := testutil.NewPrecompileContract(
 				s.T(),
 				s.Ctx,
@@ -140,6 +141,7 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
 			s.T().Log("  🔒 Funds irrecoverable once stolen")
 			s.T().Log("  👥 All users affected")
 			s.T().Log("")
+			require.Fail(s.T(), "REENTRANCY VULNERABILITY EXISTS")
 		} else if successfulReentries == 1 {
 			s.T().Log("")
 			s.T().Log("✅ Only one execution succeeded - Guard may be present")

--- a/precompiles/wasmd/realworld_attack_test.go
+++ b/precompiles/wasmd/realworld_attack_test.go
@@ -1,18 +1,23 @@
 package wasmd_test
 
 import (
-	"encoding/hex"
 	"encoding/json"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
 	storetypes "cosmossdk.io/store/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/cosmos/evm/precompiles/testutil"
 
 	wasmdprecompile "github.com/kiichain/kiichain/v5/precompiles/wasmd"
 )
+
+// Note:
+// The test TestRealWorldDataLeakage was removed because its causer was removed
+// The test TestCompareRealWorldVsUnitTest was removed because it was redundant
 
 // TestRealWorldReentrancyAttack simulates a real-world attack scenario
 // This test is closer to what would happen on an actual running chain
@@ -36,8 +41,10 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
 		// Simulate funding the victim contract (like a DeFi pool)
 		initialFunds := sdk.NewCoins(sdk.NewInt64Coin("ukii", 10000000))
 		victimAddr, _ := sdk.AccAddressFromBech32(victimContract)
-		s.App.BankKeeper.MintCoins(s.Ctx, "evm", initialFunds)
-		s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, "evm", victimAddr, initialFunds)
+		err := s.App.BankKeeper.MintCoins(s.Ctx, "evm", initialFunds)
+		require.NoError(s.T(), err)
+		err = s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, "evm", victimAddr, initialFunds)
+		require.NoError(s.T(), err)
 
 		victimBalance := s.App.BankKeeper.GetBalance(s.Ctx, victimAddr, "ukii")
 		s.T().Logf("✓ Victim contract funded: %s", victimBalance.String())
@@ -90,11 +97,14 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
 
 			_, err := s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
 
-			if err == nil {
+			// Analyze result
+			switch {
+			case err == nil:
 				successfulReentries++
 				s.T().Logf("    ⚠️  ALLOWED - Execution %d succeeded", attempt)
 				s.T().Logf("       (In real DeFi: this would be withdrawal #%d)", attempt)
-			} else if err.Error() == "reentrant call" || err.Error() == "reentrancy detected" {
+			//nolint:goconst
+			case err.Error() == "reentrant call" || err.Error() == "reentrancy detected":
 				s.T().Logf("    ✓ BLOCKED - Reentrancy guard detected: %v", err)
 				s.T().Log("")
 				s.T().Log("═══════════════════════════════════════════════")
@@ -102,7 +112,7 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
 				s.T().Log("   Guard correctly blocked second execution")
 				s.T().Log("═══════════════════════════════════════════════")
 				return // Exit early - guard is working
-			} else {
+			default:
 				s.T().Logf("    ℹ️  Failed: %v", err)
 			}
 		}
@@ -117,7 +127,9 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
 		s.T().Logf("Final Balance:    %s", finalBalance.String())
 		s.T().Logf("Successful Reentries: %d/%d", successfulReentries, attackAttempts)
 
-		if successfulReentries >= 2 {
+		// Analyze results
+		switch {
+		case successfulReentries >= 2:
 			s.T().Log("")
 			s.T().Log("════════════════════════════════════════════════")
 			s.T().Log("❌ CRITICAL: REENTRANCY VULNERABILITY CONFIRMED!")
@@ -143,10 +155,10 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
 			s.T().Log("  👥 All users affected")
 			s.T().Log("")
 			require.Fail(s.T(), "REENTRANCY VULNERABILITY EXISTS")
-		} else if successfulReentries == 1 {
+		case successfulReentries == 1:
 			s.T().Log("")
 			s.T().Log("✅ Only one execution succeeded - Guard may be present")
-		} else {
+		default:
 			s.T().Log("")
 			s.T().Log("ℹ️  No executions succeeded (contract method issue)")
 			s.T().Log("   Note: Reentrancy vulnerability still tested in other test suites")
@@ -169,15 +181,20 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldGasExhaustion() {
 		method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
 		attacker := s.keyring.GetKey(1)
 
+		expectedUsage := uint64(68137)
+
 		gasLimits := []struct {
-			name              string
-			gasLimit          uint64
-			shouldPanicOutGas bool
+			name       string
+			gasLimit   uint64
+			panicsWith interface{}
 		}{
-			{"Minimal Gas (1)", 1, true},
-			{"Low Gas (100)", 100, true},
-			{"Medium Gas (10K)", 10000, true},
-			{"Adequate Gas (200K)", 200000, false},
+			{"Minimal Gas (1)", 1, storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"}},
+			{"Low Gas (100)", 100, storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"}},
+			{"Medium Gas (10K)", 10000, storetypes.ErrorOutOfGas{Descriptor: "Loading CosmWasm module: execute"}},
+			{"Medium Gas (20K)", 20000, storetypes.ErrorOutOfGas{Descriptor: "Loading CosmWasm module: execute"}},
+			{"10 less than usage", expectedUsage - 10, storetypes.ErrorOutOfGas{Descriptor: "Custom contract event attributes"}},
+			{"10 more than usage", expectedUsage + 10, nil},
+			{"Adequate Gas (200K)", 200000, nil},
 		}
 
 		s.T().Log("Testing gas limits like on real chain:")
@@ -185,7 +202,6 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldGasExhaustion() {
 
 		// Run the tests for each gas limit
 		for _, test := range gasLimits {
-
 			stateDB := s.GetStateDB()
 			contract, ctx := testutil.NewPrecompileContract(
 				s.T(),
@@ -207,153 +223,32 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldGasExhaustion() {
 			// Measure actual gas consumed (like real chain would)
 			gasStart := ctx.GasMeter().GasConsumed()
 
-			if test.shouldPanicOutGas {
-				require.Panics(s.T(), func() {
+			if test.panicsWith != nil {
+				require.PanicsWithValue(s.T(), test.panicsWith, func() {
 					// The call panics if out of gas
 					_, _ = s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
-				}, "Expected out-of-gas panic for %s", test.name)
+				})
 				s.T().Logf("  %s: ✓ Rejected - Out of Gas panic", test.name)
 				continue
-			} else {
-				// The call panics if out of gas
-				_, err := s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
-				require.NoError(s.T(), err, "Unexpected error for %s", test.name)
-				s.T().Logf("  %s: ✓ Allowed - Executed successfully", test.name)
 			}
+
+			// The call panics if out of gas
+			_, err := s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
+			require.NoError(s.T(), err)
+			s.T().Logf("  %s: ✓ Allowed - Executed successfully", test.name)
 
 			// Check gas used
 			gasUsed := ctx.GasMeter().GasConsumed() - gasStart
+			// Log the gas used
+			s.T().Logf("    → Gas Used: %d / Limit: %d", gasUsed, test.gasLimit)
 
 			// Final gas should be less than limit
 			require.Less(s.T(), gasUsed, test.gasLimit, "Gas used should be less than limit for %s", test.name)
 			// But should be a significant portion (indicating real work done)
 			require.Greater(s.T(), gasUsed, test.gasLimit/10, "Gas used should be significant for %s", test.name)
+
 		}
 
-		s.T().Log("")
-	})
-}
-
-// TestRealWorldDataLeakage simulates log-based data leakage
-func (s *WasmdPrecompileTestSuite) TestRealWorldDataLeakage() {
-	s.Run("simulate_real_chain_log_exposure", func() {
-		s.T().Log("")
-		s.T().Log("════════════════════════════════════════════════════════════")
-		s.T().Log("  REAL WORLD DATA LEAKAGE SIMULATION")
-		s.T().Log("  Simulating how logs appear on block explorer")
-		s.T().Log("════════════════════════════════════════════════════════════")
-		s.T().Log("")
-
-		contractAddr := s.instantiateContract()
-		method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
-		user := s.keyring.GetKey(0)
-
-		// Simulate sensitive data that users might send
-		sensitivePayloads := []struct {
-			name string
-			data []byte
-		}{
-			{
-				name: "Private Key (example)",
-				data: []byte(`{"transfer": {"recipient": "kii1...", "key": "0xabcd1234..."}}`),
-			},
-			{
-				name: "Personal Data",
-				data: []byte(`{"update_profile": {"ssn": "123-45-6789", "email": "user@example.com"}}`),
-			},
-			{
-				name: "Binary Credentials",
-				data: []byte{0x00, 0x01, 0x02, 0xFF, 0xFE}, // Would be API keys, etc
-			},
-		}
-
-		s.T().Log("Simulating how data appears in real chain logs:")
-		s.T().Log("───────────────────────────────────────────────")
-		s.T().Log("")
-
-		for _, payload := range sensitivePayloads {
-			stateDB := s.GetStateDB()
-			contract, ctx := testutil.NewPrecompileContract(
-				s.T(),
-				s.Ctx,
-				user.Addr,
-				s.Precompile.Address(),
-				200000,
-			)
-
-			args := []any{
-				contractAddr,
-				payload.data,
-				[]cmn.Coin{},
-			}
-
-			s.T().Logf("Payload: %s", payload.name)
-
-			// This would appear in chain logs
-			s.Precompile.Execute(ctx, user.Addr, contract, stateDB, &method, args)
-
-			// Show how it appears in logs (UNSAFE)
-			s.T().Logf("  Logged as (current): %v", payload.data)
-			s.T().Logf("  Would appear on block explorer: %s", string(payload.data))
-
-			// Show how it SHOULD be logged (SAFE)
-			safeLog := hex.EncodeToString(payload.data)
-			if len(safeLog) > 64 {
-				safeLog = safeLog[:64] + "... (truncated)"
-			}
-			s.T().Logf("  Should be logged as:  %s", safeLog)
-			s.T().Log("")
-		}
-
-		s.T().Log("⚠️  IMPACT ON REAL CHAIN:")
-		s.T().Log("   - All transaction logs are public")
-		s.T().Log("   - Block explorers display this data")
-		s.T().Log("   - Anyone can read historical logs")
-		s.T().Log("   - Sensitive data permanently exposed")
-		s.T().Log("")
-	})
-}
-
-// TestCompareRealWorldVsUnitTest shows the differences
-func (s *WasmdPrecompileTestSuite) TestCompareRealWorldVsUnitTest() {
-	s.Run("comparison_real_vs_test", func() {
-		s.T().Log("")
-		s.T().Log("════════════════════════════════════════════════════════════")
-		s.T().Log("  REAL WORLD vs UNIT TEST COMPARISON")
-		s.T().Log("════════════════════════════════════════════════════════════")
-		s.T().Log("")
-
-		s.T().Log("WHAT'S THE SAME:")
-		s.T().Log("  ✓ Precompile code execution path")
-		s.T().Log("  ✓ WasmKeeper interactions")
-		s.T().Log("  ✓ State changes and validation")
-		s.T().Log("  ✓ Error handling logic")
-		s.T().Log("  ✓ Reentrancy vulnerability exists")
-		s.T().Log("")
-
-		s.T().Log("WHAT'S DIFFERENT:")
-		s.T().Log("  Real Chain                    Unit Test")
-		s.T().Log("  ─────────────────────────────────────────────────────")
-		s.T().Log("  Real network latency          Instant execution")
-		s.T().Log("  Consensus mechanism           Mock consensus")
-		s.T().Log("  Multiple validators           Single node")
-		s.T().Log("  Real gas costs                Simulated gas")
-		s.T().Log("  Actual transactions           Mock transactions")
-		s.T().Log("  Block production              Instant blocks")
-		s.T().Log("  Real user wallets             Test accounts")
-		s.T().Log("")
-
-		s.T().Log("VULNERABILITY CONFIDENCE:")
-		s.T().Log("  If vulnerable in tests → 99.9% vulnerable in production")
-		s.T().Log("  Reason: Same code, same execution path")
-		s.T().Log("")
-
-		s.T().Log("TO TEST ON REAL CHAIN:")
-		s.T().Log("  1. Deploy to KiiChain testnet")
-		s.T().Log("  2. Get test tokens from faucet")
-		s.T().Log("  3. Deploy malicious contract")
-		s.T().Log("  4. Execute attack transaction")
-		s.T().Log("  5. Verify reentrancy succeeds")
 		s.T().Log("")
 	})
 }

--- a/precompiles/wasmd/realworld_attack_test.go
+++ b/precompiles/wasmd/realworld_attack_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
+	storetypes "cosmossdk.io/store/types"
 	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/cosmos/evm/precompiles/testutil"
 
@@ -169,20 +170,22 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldGasExhaustion() {
 		attacker := s.keyring.GetKey(1)
 
 		gasLimits := []struct {
-			name     string
-			gasLimit uint64
-			expected string
+			name              string
+			gasLimit          uint64
+			shouldPanicOutGas bool
 		}{
-			{"Minimal Gas (1)", 1, "should reject"},
-			{"Low Gas (100)", 100, "should reject"},
-			{"Medium Gas (10K)", 10000, "should reject"},
-			{"Adequate Gas (200K)", 200000, "should succeed"},
+			{"Minimal Gas (1)", 1, true},
+			{"Low Gas (100)", 100, true},
+			{"Medium Gas (10K)", 10000, true},
+			{"Adequate Gas (200K)", 200000, false},
 		}
 
 		s.T().Log("Testing gas limits like on real chain:")
 		s.T().Log("───────────────────────────────────────────────")
 
+		// Run the tests for each gas limit
 		for _, test := range gasLimits {
+
 			stateDB := s.GetStateDB()
 			contract, ctx := testutil.NewPrecompileContract(
 				s.T(),
@@ -198,23 +201,33 @@ func (s *WasmdPrecompileTestSuite) TestRealWorldGasExhaustion() {
 				[]cmn.Coin{},
 			}
 
+			// Set the gas limit on the context
+			ctx = ctx.WithGasMeter(storetypes.NewGasMeter(test.gasLimit))
+
 			// Measure actual gas consumed (like real chain would)
 			gasStart := ctx.GasMeter().GasConsumed()
 
-			_, err := s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
+			if test.shouldPanicOutGas {
+				require.Panics(s.T(), func() {
+					// The call panics if out of gas
+					_, _ = s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
+				}, "Expected out-of-gas panic for %s", test.name)
+				s.T().Logf("  %s: ✓ Rejected - Out of Gas panic", test.name)
+				continue
+			} else {
+				// The call panics if out of gas
+				_, err := s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
+				require.NoError(s.T(), err, "Unexpected error for %s", test.name)
+				s.T().Logf("  %s: ✓ Allowed - Executed successfully", test.name)
+			}
 
+			// Check gas used
 			gasUsed := ctx.GasMeter().GasConsumed() - gasStart
 
-			if err != nil {
-				s.T().Logf("  %s: ✓ Rejected - %v", test.name, err)
-			} else {
-				s.T().Logf("  %s: ⚠️  Allowed (used %d gas, limit %d)",
-					test.name, gasUsed, test.gasLimit)
-
-				if test.gasLimit < 10000 {
-					s.T().Logf("    ⚠️  VULNERABILITY: Should have rejected low gas!")
-				}
-			}
+			// Final gas should be less than limit
+			require.Less(s.T(), gasUsed, test.gasLimit, "Gas used should be less than limit for %s", test.name)
+			// But should be a significant portion (indicating real work done)
+			require.Greater(s.T(), gasUsed, test.gasLimit/10, "Gas used should be significant for %s", test.name)
 		}
 
 		s.T().Log("")

--- a/precompiles/wasmd/realworld_attack_test.go
+++ b/precompiles/wasmd/realworld_attack_test.go
@@ -1,0 +1,344 @@
+package wasmd_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/cosmos/evm/precompiles/testutil"
+
+	wasmdprecompile "github.com/kiichain/kiichain/v5/precompiles/wasmd"
+)
+
+// TestRealWorldReentrancyAttack simulates a real-world attack scenario
+// This test is closer to what would happen on an actual running chain
+func (s *WasmdPrecompileTestSuite) TestRealWorldReentrancyAttack() {
+	s.Run("realistic_attack_with_malicious_contract", func() {
+		s.T().Log("")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("  REAL WORLD REENTRANCY ATTACK SIMULATION")
+		s.T().Log("  Simulating attack on live KiiChain")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("")
+
+		// Setup: Deploy a "victim" contract with funds
+		victimContract := s.instantiateContract()
+		attacker := s.keyring.GetKey(1) // Different account for attacker
+
+		s.T().Logf("Victim Contract: %s", victimContract)
+		s.T().Logf("Attacker Address: %s", attacker.Addr.Hex())
+		s.T().Log("")
+
+		// Simulate funding the victim contract (like a DeFi pool)
+		initialFunds := sdk.NewCoins(sdk.NewInt64Coin("ukii", 10000000))
+		victimAddr, _ := sdk.AccAddressFromBech32(victimContract)
+		s.App.BankKeeper.MintCoins(s.Ctx, "evm", initialFunds)
+		s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, "evm", victimAddr, initialFunds)
+
+		victimBalance := s.App.BankKeeper.GetBalance(s.Ctx, victimAddr, "ukii")
+		s.T().Logf("✓ Victim contract funded: %s", victimBalance.String())
+		s.T().Log("")
+
+		// Attack Phase: Simulate multiple reentrancy attempts
+		s.T().Log("ATTACK PHASE: Attempting Reentrancy Exploit")
+		s.T().Log("───────────────────────────────────────────────")
+		s.T().Log("METHODOLOGY:")
+		s.T().Log("  - Using counter contract's 'set' method")
+		s.T().Log("  - Each call should modify state")
+		s.T().Log("  - If NO guard exists → all 5 calls succeed")
+		s.T().Log("  - If guard EXISTS → only 1 call succeeds")
+		s.T().Log("")
+		s.T().Log("REAL-WORLD EQUIVALENT:")
+		s.T().Log("  - Replace 'set' with 'withdraw' on DeFi contract")
+		s.T().Log("  - Each successful call drains funds")
+		s.T().Log("  - Reentrancy = Multiple withdrawals from same balance")
+		s.T().Log("")
+
+		method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
+		attackAttempts := 5
+		successfulReentries := 0
+
+		for attempt := 1; attempt <= attackAttempts; attempt++ {
+			stateDB := s.GetStateDB()
+			contract, ctx := testutil.NewPrecompileContract(
+				s.T(),
+				s.Ctx,
+				attacker.Addr,
+				s.Precompile.Address(),
+				500000,
+			)
+
+			// Simulate state modification attack using counter's "set" method
+			// In a real attack, this would be a withdrawal or transfer
+			// The point is to show multiple executions are allowed (reentrancy)
+			setMsg := map[string]interface{}{
+				"set": attempt * 10, // Set to different values
+			}
+			msgBytes, _ := json.Marshal(setMsg)
+
+			args := []any{
+				victimContract,
+				msgBytes,
+				[]cmn.Coin{},
+			}
+
+			s.T().Logf("  Execution %d: set(value=%d)...", attempt, attempt*10)
+
+			_, err := s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
+
+			if err == nil {
+				successfulReentries++
+				s.T().Logf("    ⚠️  ALLOWED - Execution %d succeeded", attempt)
+				s.T().Logf("       (In real DeFi: this would be withdrawal #%d)", attempt)
+			} else if err.Error() == "reentrant call" || err.Error() == "reentrancy detected" {
+				s.T().Logf("    ✓ BLOCKED - Reentrancy guard detected: %v", err)
+				s.T().Log("")
+				s.T().Log("═══════════════════════════════════════════════")
+				s.T().Log("✅ PROTECTED: Reentrancy guard is functioning!")
+				s.T().Log("   Guard correctly blocked second execution")
+				s.T().Log("═══════════════════════════════════════════════")
+				return // Exit early - guard is working
+			} else {
+				s.T().Logf("    ℹ️  Failed: %v", err)
+			}
+		}
+
+		s.T().Log("")
+
+		// Check final state
+		finalBalance := s.App.BankKeeper.GetBalance(s.Ctx, victimAddr, "ukii")
+		s.T().Log("ATTACK RESULTS:")
+		s.T().Log("───────────────────────────────────────────────")
+		s.T().Logf("Initial Balance:  %s", victimBalance.String())
+		s.T().Logf("Final Balance:    %s", finalBalance.String())
+		s.T().Logf("Successful Reentries: %d/%d", successfulReentries, attackAttempts)
+
+		if successfulReentries >= 2 {
+			s.T().Log("")
+			s.T().Log("════════════════════════════════════════════════")
+			s.T().Log("❌ CRITICAL: REENTRANCY VULNERABILITY CONFIRMED!")
+			s.T().Log("════════════════════════════════════════════════")
+			s.T().Logf("   Successful Reentrancies: %d/%d", successfulReentries, attackAttempts)
+			s.T().Log("")
+			s.T().Log("WHAT THIS MEANS:")
+			s.T().Log("  ✓ No reentrancy guard exists in precompile")
+			s.T().Log("  ✓ Multiple calls execute without blocking")
+			s.T().Log("  ✓ State can be manipulated during execution")
+			s.T().Log("")
+			s.T().Log("REAL-WORLD ATTACK SCENARIO:")
+			s.T().Log("  If this was a DeFi contract with withdraw():")
+			s.T().Log("  ├─ Call 1: withdraw(1000) → Success ✓")
+			s.T().Log("  ├─ Call 2: withdraw(1000) → Success ✓ (REENTRANCY!)")
+			s.T().Log("  ├─ Call 3: withdraw(1000) → Success ✓ (REENTRANCY!)")
+			s.T().Log("  └─ Balance updated ONCE → 3000 stolen, 1000 paid")
+			s.T().Log("")
+			s.T().Log("IMPACT:")
+			s.T().Log("  💸 Drain entire contract balance")
+			s.T().Log("  ⚡ Completes in single transaction")
+			s.T().Log("  🔒 Funds irrecoverable once stolen")
+			s.T().Log("  👥 All users affected")
+			s.T().Log("")
+		} else if successfulReentries == 1 {
+			s.T().Log("")
+			s.T().Log("✅ Only one execution succeeded - Guard may be present")
+		} else {
+			s.T().Log("")
+			s.T().Log("ℹ️  No executions succeeded (contract method issue)")
+			s.T().Log("   Note: Reentrancy vulnerability still tested in other test suites")
+		}
+
+		s.T().Log("")
+	})
+}
+
+// TestRealWorldGasExhaustion simulates gas exhaustion attack
+func (s *WasmdPrecompileTestSuite) TestRealWorldGasExhaustion() {
+	s.Run("gas_exhaustion_attack_simulation", func() {
+		s.T().Log("")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("  REAL WORLD GAS EXHAUSTION ATTACK")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("")
+
+		contractAddr := s.instantiateContract()
+		method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
+		attacker := s.keyring.GetKey(1)
+
+		gasLimits := []struct {
+			name     string
+			gasLimit uint64
+			expected string
+		}{
+			{"Minimal Gas (1)", 1, "should reject"},
+			{"Low Gas (100)", 100, "should reject"},
+			{"Medium Gas (10K)", 10000, "should reject"},
+			{"Adequate Gas (200K)", 200000, "should succeed"},
+		}
+
+		s.T().Log("Testing gas limits like on real chain:")
+		s.T().Log("───────────────────────────────────────────────")
+
+		for _, test := range gasLimits {
+			stateDB := s.GetStateDB()
+			contract, ctx := testutil.NewPrecompileContract(
+				s.T(),
+				s.Ctx,
+				attacker.Addr,
+				s.Precompile.Address(),
+				test.gasLimit,
+			)
+
+			args := []any{
+				contractAddr,
+				[]byte(`{"set": 42}`),
+				[]cmn.Coin{},
+			}
+
+			// Measure actual gas consumed (like real chain would)
+			gasStart := ctx.GasMeter().GasConsumed()
+
+			_, err := s.Precompile.Execute(ctx, attacker.Addr, contract, stateDB, &method, args)
+
+			gasUsed := ctx.GasMeter().GasConsumed() - gasStart
+
+			if err != nil {
+				s.T().Logf("  %s: ✓ Rejected - %v", test.name, err)
+			} else {
+				s.T().Logf("  %s: ⚠️  Allowed (used %d gas, limit %d)",
+					test.name, gasUsed, test.gasLimit)
+
+				if test.gasLimit < 10000 {
+					s.T().Logf("    ⚠️  VULNERABILITY: Should have rejected low gas!")
+				}
+			}
+		}
+
+		s.T().Log("")
+	})
+}
+
+// TestRealWorldDataLeakage simulates log-based data leakage
+func (s *WasmdPrecompileTestSuite) TestRealWorldDataLeakage() {
+	s.Run("simulate_real_chain_log_exposure", func() {
+		s.T().Log("")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("  REAL WORLD DATA LEAKAGE SIMULATION")
+		s.T().Log("  Simulating how logs appear on block explorer")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("")
+
+		contractAddr := s.instantiateContract()
+		method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
+		user := s.keyring.GetKey(0)
+
+		// Simulate sensitive data that users might send
+		sensitivePayloads := []struct {
+			name string
+			data []byte
+		}{
+			{
+				name: "Private Key (example)",
+				data: []byte(`{"transfer": {"recipient": "kii1...", "key": "0xabcd1234..."}}`),
+			},
+			{
+				name: "Personal Data",
+				data: []byte(`{"update_profile": {"ssn": "123-45-6789", "email": "user@example.com"}}`),
+			},
+			{
+				name: "Binary Credentials",
+				data: []byte{0x00, 0x01, 0x02, 0xFF, 0xFE}, // Would be API keys, etc
+			},
+		}
+
+		s.T().Log("Simulating how data appears in real chain logs:")
+		s.T().Log("───────────────────────────────────────────────")
+		s.T().Log("")
+
+		for _, payload := range sensitivePayloads {
+			stateDB := s.GetStateDB()
+			contract, ctx := testutil.NewPrecompileContract(
+				s.T(),
+				s.Ctx,
+				user.Addr,
+				s.Precompile.Address(),
+				200000,
+			)
+
+			args := []any{
+				contractAddr,
+				payload.data,
+				[]cmn.Coin{},
+			}
+
+			s.T().Logf("Payload: %s", payload.name)
+
+			// This would appear in chain logs
+			s.Precompile.Execute(ctx, user.Addr, contract, stateDB, &method, args)
+
+			// Show how it appears in logs (UNSAFE)
+			s.T().Logf("  Logged as (current): %v", payload.data)
+			s.T().Logf("  Would appear on block explorer: %s", string(payload.data))
+
+			// Show how it SHOULD be logged (SAFE)
+			safeLog := hex.EncodeToString(payload.data)
+			if len(safeLog) > 64 {
+				safeLog = safeLog[:64] + "... (truncated)"
+			}
+			s.T().Logf("  Should be logged as:  %s", safeLog)
+			s.T().Log("")
+		}
+
+		s.T().Log("⚠️  IMPACT ON REAL CHAIN:")
+		s.T().Log("   - All transaction logs are public")
+		s.T().Log("   - Block explorers display this data")
+		s.T().Log("   - Anyone can read historical logs")
+		s.T().Log("   - Sensitive data permanently exposed")
+		s.T().Log("")
+	})
+}
+
+// TestCompareRealWorldVsUnitTest shows the differences
+func (s *WasmdPrecompileTestSuite) TestCompareRealWorldVsUnitTest() {
+	s.Run("comparison_real_vs_test", func() {
+		s.T().Log("")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("  REAL WORLD vs UNIT TEST COMPARISON")
+		s.T().Log("════════════════════════════════════════════════════════════")
+		s.T().Log("")
+
+		s.T().Log("WHAT'S THE SAME:")
+		s.T().Log("  ✓ Precompile code execution path")
+		s.T().Log("  ✓ WasmKeeper interactions")
+		s.T().Log("  ✓ State changes and validation")
+		s.T().Log("  ✓ Error handling logic")
+		s.T().Log("  ✓ Reentrancy vulnerability exists")
+		s.T().Log("")
+
+		s.T().Log("WHAT'S DIFFERENT:")
+		s.T().Log("  Real Chain                    Unit Test")
+		s.T().Log("  ─────────────────────────────────────────────────────")
+		s.T().Log("  Real network latency          Instant execution")
+		s.T().Log("  Consensus mechanism           Mock consensus")
+		s.T().Log("  Multiple validators           Single node")
+		s.T().Log("  Real gas costs                Simulated gas")
+		s.T().Log("  Actual transactions           Mock transactions")
+		s.T().Log("  Block production              Instant blocks")
+		s.T().Log("  Real user wallets             Test accounts")
+		s.T().Log("")
+
+		s.T().Log("VULNERABILITY CONFIDENCE:")
+		s.T().Log("  If vulnerable in tests → 99.9% vulnerable in production")
+		s.T().Log("  Reason: Same code, same execution path")
+		s.T().Log("")
+
+		s.T().Log("TO TEST ON REAL CHAIN:")
+		s.T().Log("  1. Deploy to KiiChain testnet")
+		s.T().Log("  2. Get test tokens from faucet")
+		s.T().Log("  3. Deploy malicious contract")
+		s.T().Log("  4. Execute attack transaction")
+		s.T().Log("  5. Verify reentrancy succeeds")
+		s.T().Log("")
+	})
+}

--- a/precompiles/wasmd/security_test.go
+++ b/precompiles/wasmd/security_test.go
@@ -1,7 +1,12 @@
 package wasmd_test
 
 import (
-	"encoding/hex"
+	"bytes"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
 
 	cmn "github.com/cosmos/evm/precompiles/common"
 	"github.com/cosmos/evm/precompiles/testutil"
@@ -108,10 +113,18 @@ func (s *WasmdPrecompileTestSuite) TestUnsafeLogging() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
+			// Start a new logger with buffer to capture logs
+			var buf bytes.Buffer
+			testLogger := log.NewLogger(&buf)
+
+			// Add to the context
+			ctx := s.Ctx.WithLogger(testLogger)
+
+			// Start the contract
 			stateDB := s.GetStateDB()
 			contract, ctx := testutil.NewPrecompileContract(
 				s.T(),
-				s.Ctx,
+				ctx,
 				account.Addr,
 				s.Precompile.Address(),
 				200000,
@@ -127,15 +140,17 @@ func (s *WasmdPrecompileTestSuite) TestUnsafeLogging() {
 			// The issue is that msg.Msg is logged as-is, which could expose binary data
 			_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
 
+			// Make the buf into a string for inspection
+			logOutput := buf.String()
+
+			// Logs should never surpass a reasonable length
+			s.Require().Less(len(logOutput), 200, "Logs should be truncated to avoid overflow")
+
 			// We expect these to fail because of invalid CosmWasm messages
 			// But the real issue is that they get logged with raw binary
 			if tc.expectError {
 				s.Require().Error(err, tc.description)
 			}
-
-			// Log what would be logged unsafely
-			s.T().Logf("Binary data logged unsafely: %v", tc.msg)
-			s.T().Logf("Safe hex encoding: %s...", hex.EncodeToString(tc.msg[:min(len(tc.msg), 32)]))
 		})
 	}
 }
@@ -148,27 +163,23 @@ func (s *WasmdPrecompileTestSuite) TestGasHandling() {
 	account := s.keyring.GetKey(0)
 
 	testCases := []struct {
-		name        string
-		gasLimit    uint64
-		expectError bool
-		errContains string
+		name              string
+		gasLimit          uint64
+		shouldPanicOutGas bool
 	}{
 		{
-			name:        "very low gas limit",
-			gasLimit:    1000,
-			expectError: true,
-			errContains: "out of gas",
+			name:              "zero gas limit",
+			gasLimit:          0,
+			shouldPanicOutGas: true,
 		},
 		{
-			name:        "adequate gas limit",
-			gasLimit:    200000,
-			expectError: false,
+			name:              "very low gas limit",
+			gasLimit:          1000,
+			shouldPanicOutGas: true,
 		},
 		{
-			name:        "zero gas limit",
-			gasLimit:    0,
-			expectError: true,
-			errContains: "out of gas",
+			name:     "adequate gas limit",
+			gasLimit: 200000,
 		},
 	}
 
@@ -189,15 +200,18 @@ func (s *WasmdPrecompileTestSuite) TestGasHandling() {
 				[]cmn.Coin{},
 			}
 
-			_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+			// Set the gas limit on the context
+			ctx = ctx.WithGasMeter(storetypes.NewGasMeter(tc.gasLimit))
 
-			if tc.expectError {
-				s.Require().Error(err, "Should fail with gas limit %d", tc.gasLimit)
-				if tc.errContains != "" {
-					s.Require().Contains(err.Error(), tc.errContains)
-				}
+			if tc.shouldPanicOutGas {
+				require.Panics(s.T(), func() {
+					// The call panics if out of gas
+					_, _ = s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+				}, "Expected out-of-gas panic for %s", tc.name)
 			} else {
-				s.Require().NoError(err, "Should succeed with gas limit %d", tc.gasLimit)
+				// Should not panic
+				_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+				s.Require().NoError(err, "Should succeed with adequate gas for %s", tc.name)
 			}
 		})
 	}
@@ -304,6 +318,7 @@ func (s *WasmdPrecompileTestSuite) TestReentrancy() {
 			s.T().Log("  3. Could drain funds or corrupt state")
 			s.T().Log("")
 			s.T().Log("IMPACT: HIGH - Cross-contract call exploitation possible")
+			require.Fail(s.T(), "Reentrancy vulnerability exists")
 		}
 	})
 
@@ -340,42 +355,6 @@ func (s *WasmdPrecompileTestSuite) TestReentrancy() {
 			s.T().Log("    This could lead to state inconsistencies")
 		}
 	})
-
-	s.Run("verify_reentrancy_guard_implementation", func() {
-		s.T().Log("")
-		s.T().Log("REENTRANCY GUARD ANALYSIS")
-		s.T().Log("════════════════════════════")
-
-		// Check the code for common reentrancy protection patterns
-		s.T().Log("Checking for protection mechanisms:")
-		s.T().Log("  [ ] Mutex lock before execution")
-		s.T().Log("  [ ] Reentrancy flag/counter")
-		s.T().Log("  [ ] Call depth tracking")
-		s.T().Log("  [ ] State commitment before callbacks")
-		s.T().Log("")
-		s.T().Log("⚠️  RECOMMENDATION:")
-		s.T().Log("    Add explicit reentrancy guard using one of:")
-		s.T().Log("    1. sync.Mutex to prevent concurrent execution")
-		s.T().Log("    2. execution status flag (locked/unlocked)")
-		s.T().Log("    3. call depth counter with maximum limit")
-		s.T().Log("")
-		s.T().Log("EXAMPLE IMPLEMENTATION:")
-		s.T().Log("  type Precompile struct {")
-		s.T().Log("      mu            sync.Mutex")
-		s.T().Log("      executing     bool")
-		s.T().Log("  }")
-		s.T().Log("")
-		s.T().Log("  func (p *Precompile) Execute(...) {")
-		s.T().Log("      p.mu.Lock()")
-		s.T().Log("      defer p.mu.Unlock()")
-		s.T().Log("      if p.executing {")
-		s.T().Log("          return nil, errors.New(\"reentrant call\")")
-		s.T().Log("      }")
-		s.T().Log("      p.executing = true")
-		s.T().Log("      defer func() { p.executing = false }()")
-		s.T().Log("      // ... rest of execution")
-		s.T().Log("  }")
-	})
 }
 
 // TestKeeperReference tests that the correct keeper is referenced
@@ -407,11 +386,4 @@ func (s *WasmdPrecompileTestSuite) TestKeeperReference() {
 		_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
 		s.Require().NoError(err, "Keeper should work correctly without typo")
 	})
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/precompiles/wasmd/security_test.go
+++ b/precompiles/wasmd/security_test.go
@@ -1,0 +1,417 @@
+package wasmd_test
+
+import (
+	"encoding/hex"
+
+	cmn "github.com/cosmos/evm/precompiles/common"
+	"github.com/cosmos/evm/precompiles/testutil"
+
+	wasmdprecompile "github.com/kiichain/kiichain/v5/precompiles/wasmd"
+)
+
+// TestInvalidCodeIDValidation tests if the precompile properly validates code_id
+// Bug Report Issue #4: No Input Validation
+func (s *WasmdPrecompileTestSuite) TestInvalidCodeIDValidation() {
+	method := s.Precompile.Methods[wasmdprecompile.InstantiateMethod]
+	account := s.keyring.GetKey(0)
+
+	testCases := []struct {
+		name        string
+		codeID      uint64
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "zero code_id should fail",
+			codeID:      0,
+			expectError: true,
+			errContains: "code id",
+		},
+		{
+			name:        "valid code_id should succeed",
+			codeID:      s.CounterCodeID,
+			expectError: false,
+		},
+		{
+			name:        "very large code_id should fail",
+			codeID:      999999999,
+			expectError: true,
+			errContains: "no such code",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			stateDB := s.GetStateDB()
+			contract, ctx := testutil.NewPrecompileContract(
+				s.T(),
+				s.Ctx,
+				account.Addr,
+				s.Precompile.Address(),
+				200000,
+			)
+
+			args := []any{
+				account.Addr,
+				tc.codeID,
+				"Test Label",
+				[]byte(`"zero"`),
+				[]cmn.Coin{},
+			}
+
+			_, err := s.Precompile.Instantiate(ctx, account.Addr, contract, stateDB, &method, args)
+
+			if tc.expectError {
+				s.Require().Error(err, "Expected error for code_id %d", tc.codeID)
+				if tc.errContains != "" {
+					s.Require().Contains(err.Error(), tc.errContains)
+				}
+			} else {
+				s.Require().NoError(err, "Should succeed with valid code_id %d", tc.codeID)
+			}
+		})
+	}
+}
+
+// TestUnsafeLogging tests if binary data in msg.Msg is logged safely
+// Bug Report Issue #3: Unsafe Logging
+func (s *WasmdPrecompileTestSuite) TestUnsafeLogging() {
+	contractAddr := s.instantiateContract()
+	method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
+	account := s.keyring.GetKey(0)
+
+	testCases := []struct {
+		name        string
+		msg         []byte
+		expectError bool
+		description string
+	}{
+		{
+			name:        "binary data with null bytes",
+			msg:         []byte{0x00, 0xFF, 0xAB, 0xCD},
+			expectError: true,
+			description: "Raw binary should be handled safely in logs",
+		},
+		{
+			name:        "very long message",
+			msg:         make([]byte, 10000),
+			expectError: true,
+			description: "Very long messages should be truncated in logs",
+		},
+		{
+			name:        "mixed binary and json",
+			msg:         append([]byte(`{"set": `), []byte{0x00, 0xFF}...),
+			expectError: true,
+			description: "Mixed content should be sanitized",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			stateDB := s.GetStateDB()
+			contract, ctx := testutil.NewPrecompileContract(
+				s.T(),
+				s.Ctx,
+				account.Addr,
+				s.Precompile.Address(),
+				200000,
+			)
+
+			args := []any{
+				contractAddr,
+				tc.msg,
+				[]cmn.Coin{},
+			}
+
+			// This call will log the message
+			// The issue is that msg.Msg is logged as-is, which could expose binary data
+			_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+
+			// We expect these to fail because of invalid CosmWasm messages
+			// But the real issue is that they get logged with raw binary
+			if tc.expectError {
+				s.Require().Error(err, tc.description)
+			}
+
+			// Log what would be logged unsafely
+			s.T().Logf("Binary data logged unsafely: %v", tc.msg)
+			s.T().Logf("Safe hex encoding: %s...", hex.EncodeToString(tc.msg[:min(len(tc.msg), 32)]))
+		})
+	}
+}
+
+// TestGasHandling tests if gas limits are properly enforced
+// Bug Report Issue #2: Missing Gas Handling
+func (s *WasmdPrecompileTestSuite) TestGasHandling() {
+	contractAddr := s.instantiateContract()
+	method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
+	account := s.keyring.GetKey(0)
+
+	testCases := []struct {
+		name        string
+		gasLimit    uint64
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "very low gas limit",
+			gasLimit:    1000,
+			expectError: true,
+			errContains: "out of gas",
+		},
+		{
+			name:        "adequate gas limit",
+			gasLimit:    200000,
+			expectError: false,
+		},
+		{
+			name:        "zero gas limit",
+			gasLimit:    0,
+			expectError: true,
+			errContains: "out of gas",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			stateDB := s.GetStateDB()
+			contract, ctx := testutil.NewPrecompileContract(
+				s.T(),
+				s.Ctx,
+				account.Addr,
+				s.Precompile.Address(),
+				tc.gasLimit,
+			)
+
+			args := []any{
+				contractAddr,
+				[]byte(`{"set": 42}`),
+				[]cmn.Coin{},
+			}
+
+			_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+
+			if tc.expectError {
+				s.Require().Error(err, "Should fail with gas limit %d", tc.gasLimit)
+				if tc.errContains != "" {
+					s.Require().Contains(err.Error(), tc.errContains)
+				}
+			} else {
+				s.Require().NoError(err, "Should succeed with gas limit %d", tc.gasLimit)
+			}
+		})
+	}
+}
+
+// TestReentrancy attempts to test for reentrancy vulnerabilities
+// Bug Report Issue #5: Reentrancy Risk
+func (s *WasmdPrecompileTestSuite) TestReentrancy() {
+	contractAddr := s.instantiateContract()
+	method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
+	account := s.keyring.GetKey(0)
+
+	s.Run("test_concurrent_execution_without_guard", func() {
+		// This simulates what would happen if two transactions
+		// tried to execute the same contract simultaneously
+		stateDB := s.GetStateDB()
+		contract, ctx := testutil.NewPrecompileContract(
+			s.T(),
+			s.Ctx,
+			account.Addr,
+			s.Precompile.Address(),
+			200000,
+		)
+
+		args := []any{
+			contractAddr,
+			[]byte(`{"set": 100}`),
+			[]cmn.Coin{},
+		}
+
+		// First execution starts
+		_, err1 := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+		s.Require().NoError(err1)
+
+		// Second execution on same contract (simulating reentrancy)
+		// In a real attack, this would be triggered from within the first execution
+		_, err2 := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+
+		// If there's no reentrancy guard, this should succeed
+		// If there IS a guard, this should fail with a reentrancy error
+		if err2 == nil {
+			s.T().Log("⚠️  VULNERABILITY: No reentrancy protection detected!")
+			s.T().Log("    Second execution succeeded without any guard")
+			s.T().Log("    A malicious contract could exploit this")
+		} else if err2.Error() == "reentrant call" || err2.Error() == "reentrancy detected" {
+			s.T().Log("✓ PROTECTED: Reentrancy guard is working")
+		}
+	})
+
+	s.Run("test_nested_execution_attack_scenario", func() {
+		// Simulate a realistic attack scenario:
+		// 1. Attacker calls Execute on Contract A
+		// 2. Contract A calls back to Execute on Contract B
+		// 3. Contract B tries to call Execute on Contract A again
+		// This should be blocked by a reentrancy guard
+
+		s.T().Log("ATTACK SCENARIO: Nested Contract Execution")
+		s.T().Log("═══════════════════════════════════════════")
+
+		stateDB := s.GetStateDB()
+		contract, ctx := testutil.NewPrecompileContract(
+			s.T(),
+			s.Ctx,
+			account.Addr,
+			s.Precompile.Address(),
+			500000, // More gas for nested calls
+		)
+
+		// Track execution depth
+		executionDepth := 0
+		maxDepth := 5
+
+		args := []any{
+			contractAddr,
+			[]byte(`{"set": 42}`),
+			[]cmn.Coin{},
+		}
+
+		s.T().Logf("Attempting %d nested executions...", maxDepth)
+
+		// Attempt nested executions
+		for i := 0; i < maxDepth; i++ {
+			_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+			if err != nil {
+				s.T().Logf("  Depth %d: BLOCKED - %v", i, err)
+				if err.Error() == "reentrant call" {
+					s.T().Log("✓ Reentrancy guard successfully prevented nested execution")
+					return
+				}
+				break
+			}
+			executionDepth++
+			s.T().Logf("  Depth %d: ALLOWED ⚠️", i)
+		}
+
+		if executionDepth == maxDepth {
+			s.T().Log("")
+			s.T().Log("❌ CRITICAL: No reentrancy guard detected!")
+			s.T().Logf("   All %d nested executions were allowed", maxDepth)
+			s.T().Log("")
+			s.T().Log("EXPLOITATION SCENARIO:")
+			s.T().Log("  1. Attacker deploys malicious contract with callback")
+			s.T().Log("  2. Contract calls Execute repeatedly before state settles")
+			s.T().Log("  3. Could drain funds or corrupt state")
+			s.T().Log("")
+			s.T().Log("IMPACT: HIGH - Cross-contract call exploitation possible")
+		}
+	})
+
+	s.Run("test_state_consistency_under_reentrancy", func() {
+		// Test if state remains consistent during potential reentrancy
+		stateDB := s.GetStateDB()
+		contract, ctx := testutil.NewPrecompileContract(
+			s.T(),
+			s.Ctx,
+			account.Addr,
+			s.Precompile.Address(),
+			200000,
+		)
+
+		// Set initial value
+		args1 := []any{
+			contractAddr,
+			[]byte(`{"set": 50}`),
+			[]cmn.Coin{},
+		}
+		_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args1)
+		s.Require().NoError(err)
+
+		// Try to execute again before state is committed (simulating reentrancy)
+		args2 := []any{
+			contractAddr,
+			[]byte(`{"set": 75}`),
+			[]cmn.Coin{},
+		}
+		_, err = s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args2)
+
+		if err == nil {
+			s.T().Log("⚠️  State modification allowed during potential reentrancy")
+			s.T().Log("    This could lead to state inconsistencies")
+		}
+	})
+
+	s.Run("verify_reentrancy_guard_implementation", func() {
+		s.T().Log("")
+		s.T().Log("REENTRANCY GUARD ANALYSIS")
+		s.T().Log("════════════════════════════")
+
+		// Check the code for common reentrancy protection patterns
+		s.T().Log("Checking for protection mechanisms:")
+		s.T().Log("  [ ] Mutex lock before execution")
+		s.T().Log("  [ ] Reentrancy flag/counter")
+		s.T().Log("  [ ] Call depth tracking")
+		s.T().Log("  [ ] State commitment before callbacks")
+		s.T().Log("")
+		s.T().Log("⚠️  RECOMMENDATION:")
+		s.T().Log("    Add explicit reentrancy guard using one of:")
+		s.T().Log("    1. sync.Mutex to prevent concurrent execution")
+		s.T().Log("    2. execution status flag (locked/unlocked)")
+		s.T().Log("    3. call depth counter with maximum limit")
+		s.T().Log("")
+		s.T().Log("EXAMPLE IMPLEMENTATION:")
+		s.T().Log("  type Precompile struct {")
+		s.T().Log("      mu            sync.Mutex")
+		s.T().Log("      executing     bool")
+		s.T().Log("  }")
+		s.T().Log("")
+		s.T().Log("  func (p *Precompile) Execute(...) {")
+		s.T().Log("      p.mu.Lock()")
+		s.T().Log("      defer p.mu.Unlock()")
+		s.T().Log("      if p.executing {")
+		s.T().Log("          return nil, errors.New(\"reentrant call\")")
+		s.T().Log("      }")
+		s.T().Log("      p.executing = true")
+		s.T().Log("      defer func() { p.executing = false }()")
+		s.T().Log("      // ... rest of execution")
+		s.T().Log("  }")
+	})
+}
+
+// TestKeeperReference tests that the correct keeper is referenced
+// Bug Report Issue #1: Typo in Keeper Reference (ALREADY FIXED)
+func (s *WasmdPrecompileTestSuite) TestKeeperReference() {
+	// This test verifies that the correct keeper (wasmdKeeper) is used
+	// The typo (pasmdKeeper) has been fixed in the current codebase
+
+	method := s.Precompile.Methods[wasmdprecompile.ExecuteMethod]
+	account := s.keyring.GetKey(0)
+	contractAddr := s.instantiateContract()
+
+	s.Run("keeper should be accessible and functional", func() {
+		stateDB := s.GetStateDB()
+		contract, ctx := testutil.NewPrecompileContract(
+			s.T(),
+			s.Ctx,
+			account.Addr,
+			s.Precompile.Address(),
+			200000,
+		)
+
+		args := []any{
+			contractAddr,
+			[]byte(`{"set": 100}`),
+			[]cmn.Coin{},
+		}
+
+		_, err := s.Precompile.Execute(ctx, account.Addr, contract, stateDB, &method, args)
+		s.Require().NoError(err, "Keeper should work correctly without typo")
+	})
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/precompiles/wasmd/tx.go
+++ b/precompiles/wasmd/tx.go
@@ -120,6 +120,7 @@ func (p Precompile) Execute(
 // ensureLock ensures that a reentrancy lock is set and not broken for the target contract
 // Reentrance lock is built using: precompile address, origin and origin nonce
 //   - Args are avoided to build the lock key, since the attacker may manipulate it
+//
 // This is done under a transient key under Cosmos SDK's stateDB
 // The lock is released at the end of the transaction by Cosmos SDK itself
 func (p Precompile) ensureLock(
@@ -144,6 +145,7 @@ func (p Precompile) ensureLock(
 }
 
 // buildReentrancyLockKey builds a deterministic lock key:
+//
 //	H( "wasmd.precompile.reentrancy.lock:", precompileAddr, originAddr, originNonce[8] )
 func buildReentrancyLockKey(
 	precompileAddr common.Address,

--- a/precompiles/wasmd/tx.go
+++ b/precompiles/wasmd/tx.go
@@ -120,7 +120,6 @@ func (p Precompile) Execute(
 // ensureLock ensures that a reentrancy lock is set and not broken for the target contract
 // Reentrance lock is built using: precompile address, origin and origin nonce
 //   - Args are avoided to build the lock key, since the attacker may manipulate it
-//
 // This is done under a transient key under Cosmos SDK's stateDB
 // The lock is released at the end of the transaction by Cosmos SDK itself
 func (p Precompile) ensureLock(

--- a/precompiles/wasmd/tx.go
+++ b/precompiles/wasmd/tx.go
@@ -145,7 +145,6 @@ func (p Precompile) ensureLock(
 }
 
 // buildReentrancyLockKey builds a deterministic lock key:
-//
 //	H( "wasmd.precompile.reentrancy.lock:", precompileAddr, originAddr, originNonce[8] )
 func buildReentrancyLockKey(
 	precompileAddr common.Address,

--- a/precompiles/wasmd/tx.go
+++ b/precompiles/wasmd/tx.go
@@ -1,11 +1,13 @@
 package wasmd
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -17,6 +19,11 @@ const (
 	InstantiateMethod = "instantiate"
 	// ExecuteMethod is the method name for executing a contract
 	ExecuteMethod = "execute"
+)
+
+var (
+	// reentrancyPerTargetNs is the namespace for the reentrancy lock per target contract
+	reentrancyPerTargetNs = []byte("wasmd.precompile.reentrancy.lock:")
 )
 
 // Instantiate executes wasmd instantiate from the precompile
@@ -78,6 +85,11 @@ func (p Precompile) Execute(
 		return nil, err
 	}
 
+	// Ensure the reentrancy lock
+	if err := p.ensureLock(ctx, origin, contract, stateDB, method); err != nil {
+		return nil, err
+	}
+
 	// Log the call
 	p.Logger(ctx).Debug(
 		"tx called",
@@ -105,4 +117,52 @@ func (p Precompile) Execute(
 
 	// Return the response
 	return method.Outputs.Pack(true)
+}
+
+// ensureLock ensures that a reentrancy lock is set and not broken for the target contract
+// Reentrance lock is built using: precompile address, origin and origin nonce
+//   - Args are avoid to build the lock key, since the attacker may manipulate it
+//
+// This is done under a transient key under Cosmos SDK's stateDB
+// The lock is released at the end of the transaction by Cosmos SDK itself
+func (p Precompile) ensureLock(
+	ctx sdk.Context,
+	origin common.Address,
+	contract *vm.Contract,
+	stateDB vm.StateDB,
+	method *abi.Method,
+) error {
+	// Build the lock key
+	lockKey := buildReentrancyLockKey(p.Address(), origin, stateDB.GetNonce(origin))
+
+	// Check if already locked
+	if stateDB.GetTransientState(p.Address(), lockKey) == common.BytesToHash([]byte{1}) {
+		return fmt.Errorf(
+			"reentrancy detected in precompile %s, method %s",
+			p.Address().Hex(), method.Name,
+		)
+	}
+
+	// Set lock
+	stateDB.SetTransientState(p.Address(), lockKey, common.BytesToHash([]byte{1}))
+	return nil
+}
+
+// buildReentrancyLockKey builds a deterministic lock key:
+//
+//	H( "wasmd.precompile.reentrancy.lock:", precompileAddr, originAddr, originNonce[8] )
+func buildReentrancyLockKey(
+	precompileAddr common.Address,
+	origin common.Address,
+	originNonce uint64,
+) common.Hash {
+	var nonceBytes [8]byte
+	binary.BigEndian.PutUint64(nonceBytes[:], originNonce)
+
+	return crypto.Keccak256Hash(
+		[]byte(reentrancyPerTargetNs),
+		precompileAddr.Bytes(),
+		origin.Bytes(),
+		nonceBytes[:],
+	)
 }

--- a/precompiles/wasmd/tx.go
+++ b/precompiles/wasmd/tx.go
@@ -119,7 +119,7 @@ func (p Precompile) Execute(
 
 // ensureLock ensures that a reentrancy lock is set and not broken for the target contract
 // Reentrance lock is built using: precompile address, origin and origin nonce
-//   - Args are avoid to build the lock key, since the attacker may manipulate it
+//   - Args are avoided to build the lock key, since the attacker may manipulate it
 //
 // This is done under a transient key under Cosmos SDK's stateDB
 // The lock is released at the end of the transaction by Cosmos SDK itself

--- a/precompiles/wasmd/tx.go
+++ b/precompiles/wasmd/tx.go
@@ -21,10 +21,8 @@ const (
 	ExecuteMethod = "execute"
 )
 
-var (
-	// reentrancyPerTargetNs is the namespace for the reentrancy lock per target contract
-	reentrancyPerTargetNs = []byte("wasmd.precompile.reentrancy.lock:")
-)
+// reentrancyPerTargetNs is the namespace for the reentrancy lock per target contract
+var reentrancyPerTargetNs = []byte("wasmd.precompile.reentrancy.lock:")
 
 // Instantiate executes wasmd instantiate from the precompile
 func (p Precompile) Instantiate(
@@ -86,7 +84,7 @@ func (p Precompile) Execute(
 	}
 
 	// Ensure the reentrancy lock
-	if err := p.ensureLock(ctx, origin, contract, stateDB, method); err != nil {
+	if err := p.ensureLock(origin, stateDB, method); err != nil {
 		return nil, err
 	}
 
@@ -126,9 +124,7 @@ func (p Precompile) Execute(
 // This is done under a transient key under Cosmos SDK's stateDB
 // The lock is released at the end of the transaction by Cosmos SDK itself
 func (p Precompile) ensureLock(
-	ctx sdk.Context,
 	origin common.Address,
-	contract *vm.Contract,
 	stateDB vm.StateDB,
 	method *abi.Method,
 ) error {
@@ -160,7 +156,7 @@ func buildReentrancyLockKey(
 	binary.BigEndian.PutUint64(nonceBytes[:], originNonce)
 
 	return crypto.Keccak256Hash(
-		[]byte(reentrancyPerTargetNs),
+		reentrancyPerTargetNs,
 		precompileAddr.Bytes(),
 		origin.Bytes(),
 		nonceBytes[:],

--- a/precompiles/wasmd/tx.go
+++ b/precompiles/wasmd/tx.go
@@ -95,8 +95,8 @@ func (p Precompile) Execute(
 		"tx called",
 		"method", method.Name,
 		"args", fmt.Sprintf(
-			"{ contract: %s, msg: %s, sender: %s }",
-			msg.Contract, msg.Msg, msg.Sender,
+			"{ contract: %s, sender: %s }",
+			msg.Contract, msg.Sender,
 		),
 	)
 


### PR DESCRIPTION
# Description

This applies fixes and tests related to the three main issues on the Wasmd precompile as reported on https://github.com/KiiChain/kiichain/blob/main/contrib/docs/wasmd_precompile_vulnerability.md

## Reetrance protection

Reetrance protection is ensured by using a transient key under the EVM db state:
- The transient lock, is applied for all senders (signers) and for each nonce
- This blocks re-calls from the same signer and nonce multiple times under the same TX execution
- Since a transient key is used, the same is cleared before the block is commit

Tests:
- Tests were updated to cover reentrance attacks

## Log

A log was printing full messages on `execute`:
- There was a possibility of nodes having issues with the message while logging
- To fix the log was updated to not carry the message 

Tests:
- Tests were updated or created to ensure logging is now constrained

## Gas

Tests:
Tests were updated to ensure gas usage

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tests added or updated
