### PR TITLE
Fix oracle votes and install oracle ante handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixed
 
 - Fix IBC unsafe log as reported on on issue [#143](https://github.com/KiiChain/kiichain/issues/143)
+- Fix Oracle module ante decorator to allow first vote and install oracle ante handlers
 
 ### Documentation
 

--- a/ante/ante_cosmos.go
+++ b/ante/ante_cosmos.go
@@ -14,6 +14,7 @@ import (
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	cosmosante "github.com/kiichain/kiichain/v5/x/feeabstraction/ante/cosmos"
+	"github.com/kiichain/kiichain/v5/x/oracle"
 )
 
 // UseFeeMarketDecorator to make the integration testing easier: we can switch off its ante and post decorators with this flag
@@ -45,6 +46,8 @@ func NewCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
+		oracle.NewSpammingPreventionDecorator(options.OracleKeeper),
+		oracle.NewVoteAloneDecorator(),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
 		evmante.NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
 	}

--- a/ante/ante_cosmos.go
+++ b/ante/ante_cosmos.go
@@ -30,6 +30,7 @@ func NewCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		),
 
 		ante.NewSetUpContextDecorator(),
+		oracle.NewVoteAloneDecorator(), // Since this only iterate TXs, it must be executed early
 		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit), // after setup context to enforce limits early
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
@@ -47,7 +48,6 @@ func NewCosmosAnteHandler(options HandlerOptions) sdk.AnteHandler {
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 		oracle.NewSpammingPreventionDecorator(options.OracleKeeper),
-		oracle.NewVoteAloneDecorator(),
 		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
 		evmante.NewGasWantedDecorator(options.EvmKeeper, options.FeeMarketKeeper),
 	}

--- a/x/oracle/ante.go
+++ b/x/oracle/ante.go
@@ -3,7 +3,9 @@ package oracle
 import (
 	"fmt"
 
-	"cosmossdk.io/errors"
+	"github.com/pkg/errors"
+
+	"cosmossdk.io/collections"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -14,13 +16,13 @@ import (
 
 // SpammingPreventionDecorator will check if
 type SpammingPreventionDecorator struct {
-	oracleKepper keeper.Keeper
+	oracleKeeper *keeper.Keeper
 }
 
 // NewSpammingPreventionDecorator creates a new instance of spamming prevention decorator
-func NewSpammingPreventionDecorator(keeper keeper.Keeper) SpammingPreventionDecorator {
+func NewSpammingPreventionDecorator(keeper *keeper.Keeper) SpammingPreventionDecorator {
 	return SpammingPreventionDecorator{
-		oracleKepper: keeper,
+		oracleKeeper: keeper,
 	}
 }
 
@@ -60,22 +62,27 @@ func (spd SpammingPreventionDecorator) CheckOracleSpamming(ctx sdk.Context, msgs
 			}
 
 			// validate the feeder delegation is valid
-			err = spd.oracleKepper.ValidateFeeder(ctx, feederAddr, valAddr)
+			err = spd.oracleKeeper.ValidateFeeder(ctx, feederAddr, valAddr)
 			if err != nil {
 				return err
 			}
 
 			// check if the validator has voted on that block height
-			spamPreventionHeight, err := spd.oracleKepper.SpamPreventionCounter.Get(ctx, valAddr)
+			spamPreventionHeight, err := spd.oracleKeeper.SpamPreventionCounter.Get(ctx, valAddr)
 			if err != nil {
-				return err
+				// If the error is not found, its because the validator has not voted before
+				if errors.Is(err, collections.ErrNotFound) {
+					spamPreventionHeight = -1
+				} else {
+					return err
+				}
 			}
 			if spamPreventionHeight == currentHeight {
 				return errors.Wrap(sdkerrors.ErrConflict, fmt.Sprintf("the validator has already submitted a vote at the current height=%d", currentHeight))
 			}
 
 			// set the anti spam block height
-			err = spd.oracleKepper.SetSpamPreventionCounterWithDefault(ctx, valAddr)
+			err = spd.oracleKeeper.SetSpamPreventionCounterWithDefault(ctx, valAddr)
 			if err != nil {
 				return err
 			}
@@ -87,7 +94,7 @@ func (spd SpammingPreventionDecorator) CheckOracleSpamming(ctx sdk.Context, msgs
 	return nil
 }
 
-// VoteAloneDecorator implements the AnteFullDecorator needed to be registrated as a decorator
+// VoteAloneDecorator implements the AnteFullDecorator needed to be registered as a decorator
 type VoteAloneDecorator struct{}
 
 // NewVoteAloneDecorator returns a new instance of VoteAloneDecorator

--- a/x/oracle/ante_test.go
+++ b/x/oracle/ante_test.go
@@ -88,7 +88,7 @@ func TestSpammingPreventionHandle(t *testing.T) {
 	invalidVoteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[5], keeper.ValAddrs[2]) // addr 3 has not been delegated by val 2
 
 	// Register anti spamming decorator
-	spammingDecorator := oracle.NewSpammingPreventionDecorator(oracleKeeper)
+	spammingDecorator := oracle.NewSpammingPreventionDecorator(&oracleKeeper)
 	anteHandler := sdk.ChainAnteDecorators(spammingDecorator)
 
 	// should skip the ante handler because the context is set as Recheck
@@ -120,4 +120,42 @@ func TestSpammingPreventionHandle(t *testing.T) {
 	require.NoError(t, err)
 	_, err = anteHandler(checkCtx, oracle.NewTestTx([]sdk.Msg{voteMsg}), false)
 	require.Error(t, err)
+}
+
+// TestSpammingPreventionDecorator_noVoteYet tests that a validator that has not voted yet is allowed to vote
+func TestSpammingPreventionDecorator_noVoteYet(t *testing.T) {
+	// Prepare env
+	input, _ := oracle.SetUp(t)
+	ctx := input.Ctx
+	oracleKeeper := input.OracleKeeper
+
+	// Update the block height to 10
+	ctx = ctx.WithBlockHeight(10)
+
+	// Create test exchange rate
+	randomAExchangeRate := math.LegacyNewDec(1700)
+	exchangeRate := randomAExchangeRate.String() + utils.AtomDenom
+
+	voteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[0], keeper.ValAddrs[0])
+
+	// Register anti spamming decorator
+	spammingDecorator := oracle.NewSpammingPreventionDecorator(&oracleKeeper)
+	anteHandler := sdk.ChainAnteDecorators(spammingDecorator)
+
+	// should allow the vote since the validator has not voted yet
+	checkCtx := ctx.WithIsCheckTx(true)
+	_, err := anteHandler(checkCtx, oracle.NewTestTx([]sdk.Msg{voteMsg}), false)
+	require.NoError(t, err)
+
+	// try to vote again in the same block, should fail
+	_, err = anteHandler(checkCtx, oracle.NewTestTx([]sdk.Msg{voteMsg}), false)
+	require.Error(t, err)
+
+	// move to next block
+	ctx = ctx.WithBlockHeight(11)
+
+	// should allow the vote since it's a new block
+	checkCtx = ctx.WithIsCheckTx(true)
+	_, err = anteHandler(checkCtx, oracle.NewTestTx([]sdk.Msg{voteMsg}), false)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
# Description

This PR fixes a bad logic for Oracle spam detection:
- New validators were not able to vote due to the missing spam set
- Oracle ante handlers were also installed

Related to issue #148

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tests updated or added
