### PR TITLE
Correct error passing on tokenfactory wasmbinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix wasmd precompile bad input handling for coins [#147](https://github.com/KiiChain/kiichain/issues/147)
 - Fix Oracle module ante decorator to allow first vote and install oracle ante handlers
 - Fix IBC validation of negative numbers happens a bit early [#144](https://github.com/KiiChain/kiichain/issues/144)
+- Fix incorrect error passing on tokenfactory wasmbinding
 
 ### Documentation
 

--- a/wasmbinding/tokenfactory/message_plugin.go
+++ b/wasmbinding/tokenfactory/message_plugin.go
@@ -1,6 +1,8 @@
 package tokenfactory
 
 import (
+	"fmt"
+
 	wasmvmtypes "github.com/CosmWasm/wasmvm/v3/types"
 
 	errorsmod "cosmossdk.io/errors"
@@ -128,7 +130,7 @@ func PerformMint(f *tokenfactorykeeper.Keeper, b bankkeeper.Keeper, ctx sdk.Cont
 	}
 
 	if b.BlockedAddr(rcpt) {
-		return errorsmod.Wrapf(err, "minting coins to blocked address %s", rcpt.String())
+		return fmt.Errorf("minting coins to blocked address %s", rcpt.String())
 	}
 
 	err = b.SendCoins(ctx, contractAddr, rcpt, sdk.NewCoins(coin))


### PR DESCRIPTION
# Description

An incorrect error was being passed on the message of the blocked address error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)