### PR TITLE
Refresh account information before usage on cosmos ante

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix Oracle module ante decorator to allow first vote and install oracle ante handlers
 - Fix IBC validation of negative numbers happens a bit early [#144](https://github.com/KiiChain/kiichain/issues/144)
 - Fix incorrect error passing on tokenfactory wasmbinding
+- Fix account balance information being stale on fee abstraction's cosmos' ante
 
 ### Documentation
 

--- a/x/feeabstraction/ante/cosmos/fee.go
+++ b/x/feeabstraction/ante/cosmos/fee.go
@@ -140,7 +140,7 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 			return err
 		}
 
-		// Fetch info again, it can't be nil since we already checked it before
+		// Refresh info, it can't be nil since we checked it exists before
 		deductFeesFromAcc = dfd.accountKeeper.GetAccount(ctx, deductFeesFrom)
 
 		// Deduct the fees from the fee payer account

--- a/x/feeabstraction/ante/cosmos/fee.go
+++ b/x/feeabstraction/ante/cosmos/fee.go
@@ -140,6 +140,9 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 			return err
 		}
 
+		// Fetch info again, it can't be nil since we already checked it before
+		deductFeesFromAcc = dfd.accountKeeper.GetAccount(ctx, deductFeesFrom)
+
 		// Deduct the fees from the fee payer account
 		err = ante.DeductFees(dfd.bankKeeper, ctx, deductFeesFromAcc, convertedFee)
 		if err != nil {


### PR DESCRIPTION
# Description

Refreshes account info before using it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`make test-unit`
