### PR TITLE
Disable EVM mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-- Fix EVM mempool broadcast failure on public node
+- Disable EVM mempool due to bug on public nodes broadcast
 
 ## v6.0.0 - 2025-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-- Use genesis values for EVM mempool block gas limit
+- Fix EVM mempool broadcast failure on public node
 
 ## v6.0.0 - 2025-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
-## v6.0.0 - 2025-11-13
+## UNRELEASED
+
+## Fixed
+
+- Use genesis values for EVM mempool block gas limit
+
+## v6.0.0 - 2025-11-25
 
 ## Added
 

--- a/app/app.go
+++ b/app/app.go
@@ -42,7 +42,6 @@ import (
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	sigtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -279,28 +278,7 @@ func NewKiichainApp(
 
 	// set the EVM priority nonce mempool
 	if evmtypes.GetChainConfig() != nil {
-		// TODO: Get the actual block gas limit from consensus parameters
-		mempoolConfig := &evmmempool.EVMMempoolConfig{
-			AnteHandler:   app.GetAnteHandler(),
-			BlockGasLimit: 100_000_000,
-		}
-
-		evmMempool := evmmempool.NewExperimentalEVMMempool(app.CreateQueryContext, logger, app.EVMKeeper, app.FeeMarketKeeper, app.txConfig, app.clientCtx, mempoolConfig)
-		app.EVMMempool = evmMempool
-
-		// Set the global mempool for RPC access
-		if evmmempool.GetGlobalEVMMempool() == nil {
-			if err := evmmempool.SetGlobalEVMMempool(evmMempool); err != nil {
-				panic(err)
-			}
-		}
-		app.SetMempool(evmMempool)
-		checkTxHandler := evmmempool.NewCheckTxHandler(evmMempool)
-		app.SetCheckTxHandler(checkTxHandler)
-
-		abciProposalHandler := baseapp.NewDefaultProposalHandler(evmMempool, app)
-		abciProposalHandler.SetSignerExtractionAdapter(evmmempool.NewEthSignerExtractionAdapter(sdkmempool.NewDefaultSignerExtractionAdapter()))
-		app.SetPrepareProposal(abciProposalHandler.PrepareProposalHandler())
+		app.SetupMempool(appOpts, logger)
 	}
 
 	if manager := app.SnapshotManager(); manager != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -486,7 +486,6 @@ func (app *KiichainApp) RegisterTendermintService(clientCtx client.Context) {
 		app.interfaceRegistry,
 		app.Query,
 	)
-	app.SetClientCtx(clientCtx)
 }
 
 // configure store loader that checks if version == upgradeHeight and applies store upgrades

--- a/app/app.go
+++ b/app/app.go
@@ -63,7 +63,6 @@ import (
 	evmmempool "github.com/cosmos/evm/mempool"
 	srvflags "github.com/cosmos/evm/server/flags"
 	cosmosevmtypes "github.com/cosmos/evm/types"
-	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	kiiante "github.com/kiichain/kiichain/v6/ante"
 	"github.com/kiichain/kiichain/v6/app/keepers"
@@ -277,9 +276,11 @@ func NewKiichainApp(
 	app.setAnteHandler(app.txConfig, maxGasWanted, appOpts)
 
 	// set the EVM priority nonce mempool
-	if evmtypes.GetChainConfig() != nil {
-		app.SetupEVMMempool(appOpts, logger)
-	}
+	// Mempool is currently disabled due to a bug in EVM mempool on public nodes
+	// It will be enabled again once the bug is fixed on EVM
+	// if evmtypes.GetChainConfig() != nil {
+	// 	app.SetupEVMMempool(appOpts, logger)
+	// }
 
 	if manager := app.SnapshotManager(); manager != nil {
 		err = manager.RegisterExtensions(wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.AppKeepers.WasmKeeper))

--- a/app/app.go
+++ b/app/app.go
@@ -278,7 +278,7 @@ func NewKiichainApp(
 
 	// set the EVM priority nonce mempool
 	if evmtypes.GetChainConfig() != nil {
-		app.SetupMempool(appOpts, logger)
+		app.SetupEVMMempool(appOpts, logger)
 	}
 
 	if manager := app.SnapshotManager(); manager != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -486,6 +486,7 @@ func (app *KiichainApp) RegisterTendermintService(clientCtx client.Context) {
 		app.interfaceRegistry,
 		app.Query,
 	)
+	app.SetClientCtx(clientCtx)
 }
 
 // configure store loader that checks if version == upgradeHeight and applies store upgrades

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -1,0 +1,94 @@
+package kiichain
+
+import (
+	"math"
+	"path/filepath"
+
+	"github.com/spf13/cast"
+
+	"cosmossdk.io/log"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+
+	evmmempool "github.com/cosmos/evm/mempool"
+)
+
+func (app *KiichainApp) SetupMempool(appOpts servertypes.AppOptions, logger log.Logger) {
+	mempoolConfig := &evmmempool.EVMMempoolConfig{
+		AnteHandler:   app.GetAnteHandler(),
+		BlockGasLimit: GetBlockGasLimit(appOpts, logger),
+	}
+
+	evmMempool := evmmempool.NewExperimentalEVMMempool(app.CreateQueryContext, logger, app.EVMKeeper, app.FeeMarketKeeper, app.txConfig, app.clientCtx, mempoolConfig)
+	app.EVMMempool = evmMempool
+
+	// Set the global mempool for RPC access
+	if evmmempool.GetGlobalEVMMempool() == nil {
+		if err := evmmempool.SetGlobalEVMMempool(evmMempool); err != nil {
+			panic(err)
+		}
+	}
+	app.SetMempool(evmMempool)
+	checkTxHandler := evmmempool.NewCheckTxHandler(evmMempool)
+	app.SetCheckTxHandler(checkTxHandler)
+
+	abciProposalHandler := baseapp.NewDefaultProposalHandler(evmMempool, app)
+	abciProposalHandler.SetSignerExtractionAdapter(evmmempool.NewEthSignerExtractionAdapter(sdkmempool.NewDefaultSignerExtractionAdapter()))
+	app.SetPrepareProposal(abciProposalHandler.PrepareProposalHandler())
+}
+
+// GetBlockGasLimit reads the genesis json file using AppGenesisFromFile
+// to extract the consensus block gas limit before InitChain is called.
+func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
+	if appOpts == nil {
+		logger.Error("app options is nil, using zero block gas limit")
+		return math.MaxUint64
+	}
+
+	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
+	if homeDir == "" {
+		logger.Error("home directory not found in app options, using zero block gas limit")
+		return math.MaxUint64
+	}
+	genesisPath := filepath.Join(homeDir, "config", "genesis.json")
+
+	appGenesis, err := genutiltypes.AppGenesisFromFile(genesisPath)
+	if err != nil {
+		logger.Error("failed to load genesis using SDK AppGenesisFromFile, using zero block gas limit", "path", genesisPath, "error", err)
+		return 0
+	}
+	genDoc, err := appGenesis.ToGenesisDoc()
+	if err != nil {
+		logger.Error("failed to convert AppGenesis to GenesisDoc, using zero block gas limit", "path", genesisPath, "error", err)
+		return 0
+	}
+
+	if genDoc.ConsensusParams == nil {
+		logger.Error("consensus parameters not found in genesis (nil), using zero block gas limit")
+		return 0
+	}
+
+	maxGas := genDoc.ConsensusParams.Block.MaxGas
+	if maxGas == -1 {
+		logger.Warn("genesis max_gas is unlimited (-1), using max uint64")
+		return math.MaxUint64
+	}
+	if maxGas < -1 {
+		logger.Error("invalid max_gas value in genesis, using zero block gas limit")
+		return 0
+	}
+	blockGasLimit := uint64(maxGas) // #nosec G115 -- maxGas >= 0 checked above
+
+	logger.Debug(
+		"extracted block gas limit from genesis using SDK AppGenesisFromFile",
+		"genesis_path", genesisPath,
+		"max_gas", maxGas,
+		"block_gas_limit", blockGasLimit,
+	)
+
+	return blockGasLimit
+}

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -1,6 +1,7 @@
 package kiichain
 
 import (
+	"math"
 	"path/filepath"
 
 	"github.com/spf13/cast"
@@ -75,7 +76,7 @@ func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 
 	maxGas := genDoc.ConsensusParams.Block.MaxGas
 	if maxGas == -1 {
 		logger.Warn("genesis max_gas is unlimited (-1), using max uint64")
-		return 0
+		return math.MaxUint64
 	}
 	if maxGas < -1 {
 		logger.Error("invalid max_gas value in genesis, using zero block gas limit")

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -1,19 +1,25 @@
 package kiichain
 
 import (
+	"fmt"
+
 	"cosmossdk.io/log"
+
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 
 	evmmempool "github.com/cosmos/evm/mempool"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
 )
 
 // SetupEVMMempool creates and sets the EVM mempool
 func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger log.Logger) {
 	mempoolConfig := &evmmempool.EVMMempoolConfig{
-		AnteHandler: app.GetAnteHandler(),
+		AnteHandler:   app.GetAnteHandler(),
+		BroadCastTxFn: app.broadcastEVMTransactions,
 	}
 
 	evmMempool := evmmempool.NewExperimentalEVMMempool(app.CreateQueryContext, logger, app.EVMKeeper, app.FeeMarketKeeper, app.txConfig, app.clientCtx, mempoolConfig)
@@ -32,4 +38,34 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 	abciProposalHandler := baseapp.NewDefaultProposalHandler(evmMempool, app)
 	abciProposalHandler.SetSignerExtractionAdapter(evmmempool.NewEthSignerExtractionAdapter(sdkmempool.NewDefaultSignerExtractionAdapter()))
 	app.SetPrepareProposal(abciProposalHandler.PrepareProposalHandler())
+}
+
+// broadcastEVMTransactions converts Ethereum transactions to Cosmos SDK format and broadcasts them.
+// This function wraps EVM transactions in MsgEthereumTx messages and submits them to the network
+// using the provided client context. It handles encoding and error reporting for each transaction.
+// TODO: Remove once EVM pushes a fix
+func (app *KiichainApp) broadcastEVMTransactions(ethTxs []*ethtypes.Transaction) error {
+	for _, ethTx := range ethTxs {
+		msg := &evmtypes.MsgEthereumTx{}
+		msg.FromEthereumTx(ethTx)
+
+		txBuilder := app.txConfig.NewTxBuilder()
+		if err := txBuilder.SetMsgs(msg); err != nil {
+			return fmt.Errorf("failed to set msg in tx builder: %w", err)
+		}
+
+		txBytes, err := app.txConfig.TxEncoder()(txBuilder.GetTx())
+		if err != nil {
+			return fmt.Errorf("failed to encode transaction: %w", err)
+		}
+
+		res, err := app.clientCtx.BroadcastTxSync(txBytes)
+		if err != nil {
+			return fmt.Errorf("failed to broadcast transaction %s: %w", ethTx.Hash().Hex(), err)
+		}
+		if res.Code != 0 {
+			return fmt.Errorf("transaction %s rejected by mempool: code=%d, log=%s", ethTx.Hash().Hex(), res.Code, res.RawLog)
+		}
+	}
+	return nil
 }

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -16,7 +16,8 @@ import (
 	evmmempool "github.com/cosmos/evm/mempool"
 )
 
-func (app *KiichainApp) SetupMempool(appOpts servertypes.AppOptions, logger log.Logger) {
+// SetupEVMMempool creates and sets the EVM mempool
+func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger log.Logger) {
 	mempoolConfig := &evmmempool.EVMMempoolConfig{
 		AnteHandler:   app.GetAnteHandler(),
 		BlockGasLimit: GetBlockGasLimit(appOpts, logger),

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -46,14 +46,14 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 // to extract the consensus block gas limit before InitChain is called.
 func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
 	if appOpts == nil {
-		logger.Error("app options is nil, using zero block gas limit")
-		return 0
+		logger.Error("app options is nil, using max block gas limit")
+		return math.MaxUint64
 	}
 
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	if homeDir == "" {
-		logger.Error("home directory not found in app options, using zero block gas limit")
-		return 0
+		logger.Error("home directory not found in app options, using max block gas limit")
+		return math.MaxUint64
 	}
 	genesisPath := filepath.Join(homeDir, "config", "genesis.json")
 

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -1,10 +1,6 @@
 package kiichain
 
 import (
-	"fmt"
-
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-
 	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -12,14 +8,12 @@ import (
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 
 	evmmempool "github.com/cosmos/evm/mempool"
-	evmtypes "github.com/cosmos/evm/x/vm/types"
 )
 
 // SetupEVMMempool creates and sets the EVM mempool
 func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger log.Logger) {
 	mempoolConfig := &evmmempool.EVMMempoolConfig{
 		AnteHandler:   app.GetAnteHandler(),
-		BroadCastTxFn: app.broadcastEVMTransactions,
 		BlockGasLimit: 100_000_000,
 	}
 
@@ -39,37 +33,4 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 	abciProposalHandler := baseapp.NewDefaultProposalHandler(evmMempool, app)
 	abciProposalHandler.SetSignerExtractionAdapter(evmmempool.NewEthSignerExtractionAdapter(sdkmempool.NewDefaultSignerExtractionAdapter()))
 	app.SetPrepareProposal(abciProposalHandler.PrepareProposalHandler())
-}
-
-// broadcastEVMTransactions converts Ethereum transactions to Cosmos SDK format and broadcasts them.
-// This function wraps EVM transactions in MsgEthereumTx messages and submits them to the network
-// using the provided client context. It handles encoding and error reporting for each transaction.
-// TODO: Remove once EVM pushes a fix
-func (app *KiichainApp) broadcastEVMTransactions(ethTxs []*ethtypes.Transaction) error {
-	for _, ethTx := range ethTxs {
-		msg := &evmtypes.MsgEthereumTx{}
-		ethSigner := ethtypes.LatestSigner(evmtypes.GetEthChainConfig())
-		if err := msg.FromSignedEthereumTx(ethTx, ethSigner); err != nil {
-			return fmt.Errorf("failed to convert ethereum transaction: %w", err)
-		}
-
-		cosmosTx, err := msg.BuildTx(app.clientCtx.TxConfig.NewTxBuilder(), "akii")
-		if err != nil {
-			return fmt.Errorf("failed to build cosmos tx: %w", err)
-		}
-
-		txBytes, err := app.clientCtx.TxConfig.TxEncoder()(cosmosTx)
-		if err != nil {
-			return fmt.Errorf("failed to encode transaction: %w", err)
-		}
-
-		res, err := app.clientCtx.BroadcastTxSync(txBytes)
-		if err != nil {
-			return fmt.Errorf("failed to broadcast transaction %s: %w", ethTx.Hash().Hex(), err)
-		}
-		if res.Code != 0 && res.Code != 19 {
-			return fmt.Errorf("transaction %s rejected by mempool: code=%d, log=%s", ethTx.Hash().Hex(), res.Code, res.RawLog)
-		}
-	}
-	return nil
 }

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -1,29 +1,19 @@
 package kiichain
 
 import (
-	"math"
-	"path/filepath"
-
-	"github.com/spf13/cast"
-
 	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
-	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 
 	evmmempool "github.com/cosmos/evm/mempool"
 )
 
-var defaultBlockGasLimit uint64 = 100_000_000
-
 // SetupEVMMempool creates and sets the EVM mempool
 func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger log.Logger) {
 	mempoolConfig := &evmmempool.EVMMempoolConfig{
-		AnteHandler:   app.GetAnteHandler(),
-		BlockGasLimit: getBlockGasLimit(appOpts, logger),
+		AnteHandler: app.GetAnteHandler(),
 	}
 
 	evmMempool := evmmempool.NewExperimentalEVMMempool(app.CreateQueryContext, logger, app.EVMKeeper, app.FeeMarketKeeper, app.txConfig, app.clientCtx, mempoolConfig)
@@ -42,69 +32,4 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 	abciProposalHandler := baseapp.NewDefaultProposalHandler(evmMempool, app)
 	abciProposalHandler.SetSignerExtractionAdapter(evmmempool.NewEthSignerExtractionAdapter(sdkmempool.NewDefaultSignerExtractionAdapter()))
 	app.SetPrepareProposal(abciProposalHandler.PrepareProposalHandler())
-}
-
-// getBlockGasLimit fetches block gas limit and set to default if 0
-// Similar behavior is done on EVM v0.5, but its broken on v0.4.2 due to consuming
-// the value before checking if 0 and overriding
-// REMOVE once on evm v0.5 and its fixed https://github.com/KiiChain/evm/blob/feat/fork-v0.5.1/mempool/mempool.go#L109-L112
-func getBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
-	gasLimit := fetchBlockGasLimit(appOpts, logger)
-	if gasLimit == 0 {
-		gasLimit = defaultBlockGasLimit
-	}
-	return gasLimit
-}
-
-// getBlockGasLimit reads the genesis json file using AppGenesisFromFile
-// to extract the consensus block gas limit before InitChain is called.
-// IMPORT from evm v0.5 once available https://github.com/KiiChain/evm/blob/04ce2e103f6f8d2e843c9bbdcdb3d266f14073b6/config/server_app_options.go#L22-L72
-func fetchBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
-	if appOpts == nil {
-		logger.Error("app options is nil, using default gas limit")
-		return 0
-	}
-
-	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
-	if homeDir == "" {
-		logger.Error("home directory not found in app options, using default block gas limit")
-		return 0
-	}
-	genesisPath := filepath.Join(homeDir, "config", "genesis.json")
-
-	appGenesis, err := genutiltypes.AppGenesisFromFile(genesisPath)
-	if err != nil {
-		logger.Error("failed to load genesis using SDK AppGenesisFromFile, using default block gas limit", "path", genesisPath, "error", err)
-		return 0
-	}
-	genDoc, err := appGenesis.ToGenesisDoc()
-	if err != nil {
-		logger.Error("failed to convert AppGenesis to GenesisDoc, using default block gas limit", "path", genesisPath, "error", err)
-		return 0
-	}
-
-	if genDoc.ConsensusParams == nil {
-		logger.Error("consensus parameters not found in genesis (nil), using default block gas limit")
-		return 0
-	}
-
-	maxGas := genDoc.ConsensusParams.Block.MaxGas
-	if maxGas == -1 {
-		logger.Warn("genesis max_gas is unlimited (-1), using max uint64")
-		return math.MaxUint64
-	}
-	if maxGas < -1 {
-		logger.Error("invalid max_gas value in genesis, using default block gas limit")
-		return 0
-	}
-	blockGasLimit := uint64(maxGas) // #nosec G115 -- maxGas >= 0 checked above
-
-	logger.Debug(
-		"extracted block gas limit from genesis using SDK AppGenesisFromFile",
-		"genesis_path", genesisPath,
-		"max_gas", maxGas,
-		"block_gas_limit", blockGasLimit,
-	)
-
-	return blockGasLimit
 }

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -17,6 +17,8 @@ import (
 	evmmempool "github.com/cosmos/evm/mempool"
 )
 
+var defaultBlockGasLimit uint64 = 100_000_000
+
 // SetupEVMMempool creates and sets the EVM mempool
 func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger log.Logger) {
 	mempoolConfig := &evmmempool.EVMMempoolConfig{
@@ -46,31 +48,31 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 // to extract the consensus block gas limit before InitChain is called.
 func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
 	if appOpts == nil {
-		logger.Error("app options is nil, using max block gas limit")
-		return math.MaxUint64
+		logger.Error("app options is nil, using default gas limit")
+		return defaultBlockGasLimit
 	}
 
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	if homeDir == "" {
-		logger.Error("home directory not found in app options, using max block gas limit")
-		return math.MaxUint64
+		logger.Error("home directory not found in app options, using default block gas limit")
+		return defaultBlockGasLimit
 	}
 	genesisPath := filepath.Join(homeDir, "config", "genesis.json")
 
 	appGenesis, err := genutiltypes.AppGenesisFromFile(genesisPath)
 	if err != nil {
-		logger.Error("failed to load genesis using SDK AppGenesisFromFile, using zero block gas limit", "path", genesisPath, "error", err)
-		return 0
+		logger.Error("failed to load genesis using SDK AppGenesisFromFile, using default block gas limit", "path", genesisPath, "error", err)
+		return defaultBlockGasLimit
 	}
 	genDoc, err := appGenesis.ToGenesisDoc()
 	if err != nil {
-		logger.Error("failed to convert AppGenesis to GenesisDoc, using zero block gas limit", "path", genesisPath, "error", err)
-		return 0
+		logger.Error("failed to convert AppGenesis to GenesisDoc, using default block gas limit", "path", genesisPath, "error", err)
+		return defaultBlockGasLimit
 	}
 
 	if genDoc.ConsensusParams == nil {
-		logger.Error("consensus parameters not found in genesis (nil), using zero block gas limit")
-		return 0
+		logger.Error("consensus parameters not found in genesis (nil), using default block gas limit")
+		return defaultBlockGasLimit
 	}
 
 	maxGas := genDoc.ConsensusParams.Block.MaxGas
@@ -79,8 +81,8 @@ func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 
 		return math.MaxUint64
 	}
 	if maxGas < -1 {
-		logger.Error("invalid max_gas value in genesis, using zero block gas limit")
-		return 0
+		logger.Error("invalid max_gas value in genesis, using default block gas limit")
+		return defaultBlockGasLimit
 	}
 	blockGasLimit := uint64(maxGas) // #nosec G115 -- maxGas >= 0 checked above
 

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -23,7 +23,7 @@ var defaultBlockGasLimit uint64 = 100_000_000
 func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger log.Logger) {
 	mempoolConfig := &evmmempool.EVMMempoolConfig{
 		AnteHandler:   app.GetAnteHandler(),
-		BlockGasLimit: GetBlockGasLimit(appOpts, logger),
+		BlockGasLimit: getBlockGasLimit(appOpts, logger),
 	}
 
 	evmMempool := evmmempool.NewExperimentalEVMMempool(app.CreateQueryContext, logger, app.EVMKeeper, app.FeeMarketKeeper, app.txConfig, app.clientCtx, mempoolConfig)
@@ -44,35 +44,46 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 	app.SetPrepareProposal(abciProposalHandler.PrepareProposalHandler())
 }
 
-// GetBlockGasLimit reads the genesis json file using AppGenesisFromFile
+// getBlockGasLimit fetches block gas limit and set to default if 0
+// Similar behavior is done on EVM v0.5, but its broken on v0.4.2 due to consuming
+// the value before checking if 0 and overriding
+func getBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
+	gasLimit := fetchBlockGasLimit(appOpts, logger)
+	if gasLimit == 0 {
+		gasLimit = defaultBlockGasLimit
+	}
+	return gasLimit
+}
+
+// getBlockGasLimit reads the genesis json file using AppGenesisFromFile
 // to extract the consensus block gas limit before InitChain is called.
-func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
+func fetchBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
 	if appOpts == nil {
 		logger.Error("app options is nil, using default gas limit")
-		return defaultBlockGasLimit
+		return 0
 	}
 
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	if homeDir == "" {
 		logger.Error("home directory not found in app options, using default block gas limit")
-		return defaultBlockGasLimit
+		return 0
 	}
 	genesisPath := filepath.Join(homeDir, "config", "genesis.json")
 
 	appGenesis, err := genutiltypes.AppGenesisFromFile(genesisPath)
 	if err != nil {
 		logger.Error("failed to load genesis using SDK AppGenesisFromFile, using default block gas limit", "path", genesisPath, "error", err)
-		return defaultBlockGasLimit
+		return 0
 	}
 	genDoc, err := appGenesis.ToGenesisDoc()
 	if err != nil {
 		logger.Error("failed to convert AppGenesis to GenesisDoc, using default block gas limit", "path", genesisPath, "error", err)
-		return defaultBlockGasLimit
+		return 0
 	}
 
 	if genDoc.ConsensusParams == nil {
 		logger.Error("consensus parameters not found in genesis (nil), using default block gas limit")
-		return defaultBlockGasLimit
+		return 0
 	}
 
 	maxGas := genDoc.ConsensusParams.Block.MaxGas
@@ -82,7 +93,7 @@ func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 
 	}
 	if maxGas < -1 {
 		logger.Error("invalid max_gas value in genesis, using default block gas limit")
-		return defaultBlockGasLimit
+		return 0
 	}
 	blockGasLimit := uint64(maxGas) // #nosec G115 -- maxGas >= 0 checked above
 

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -47,6 +47,7 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 // getBlockGasLimit fetches block gas limit and set to default if 0
 // Similar behavior is done on EVM v0.5, but its broken on v0.4.2 due to consuming
 // the value before checking if 0 and overriding
+// REMOVE once on evm v0.5 and its fixed https://github.com/KiiChain/evm/blob/feat/fork-v0.5.1/mempool/mempool.go#L109-L112
 func getBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
 	gasLimit := fetchBlockGasLimit(appOpts, logger)
 	if gasLimit == 0 {
@@ -57,6 +58,7 @@ func getBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 
 
 // getBlockGasLimit reads the genesis json file using AppGenesisFromFile
 // to extract the consensus block gas limit before InitChain is called.
+// IMPORT from evm v0.5 once available https://github.com/KiiChain/evm/blob/04ce2e103f6f8d2e843c9bbdcdb3d266f14073b6/config/server_app_options.go#L22-L72
 func fetchBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
 	if appOpts == nil {
 		logger.Error("app options is nil, using default gas limit")

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -3,9 +3,9 @@ package kiichain
 import (
 	"fmt"
 
-	"cosmossdk.io/log"
-
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -20,6 +20,7 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 	mempoolConfig := &evmmempool.EVMMempoolConfig{
 		AnteHandler:   app.GetAnteHandler(),
 		BroadCastTxFn: app.broadcastEVMTransactions,
+		BlockGasLimit: 100_000_000,
 	}
 
 	evmMempool := evmmempool.NewExperimentalEVMMempool(app.CreateQueryContext, logger, app.EVMKeeper, app.FeeMarketKeeper, app.txConfig, app.clientCtx, mempoolConfig)

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -1,7 +1,6 @@
 package kiichain
 
 import (
-	"math"
 	"path/filepath"
 
 	"github.com/spf13/cast"
@@ -46,13 +45,13 @@ func (app *KiichainApp) SetupMempool(appOpts servertypes.AppOptions, logger log.
 func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 {
 	if appOpts == nil {
 		logger.Error("app options is nil, using zero block gas limit")
-		return math.MaxUint64
+		return 0
 	}
 
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	if homeDir == "" {
 		logger.Error("home directory not found in app options, using zero block gas limit")
-		return math.MaxUint64
+		return 0
 	}
 	genesisPath := filepath.Join(homeDir, "config", "genesis.json")
 
@@ -75,7 +74,7 @@ func GetBlockGasLimit(appOpts servertypes.AppOptions, logger log.Logger) uint64 
 	maxGas := genDoc.ConsensusParams.Block.MaxGas
 	if maxGas == -1 {
 		logger.Warn("genesis max_gas is unlimited (-1), using max uint64")
-		return math.MaxUint64
+		return 0
 	}
 	if maxGas < -1 {
 		logger.Error("invalid max_gas value in genesis, using zero block gas limit")

--- a/app/evm_mempool.go
+++ b/app/evm_mempool.go
@@ -48,14 +48,17 @@ func (app *KiichainApp) SetupEVMMempool(appOpts servertypes.AppOptions, logger l
 func (app *KiichainApp) broadcastEVMTransactions(ethTxs []*ethtypes.Transaction) error {
 	for _, ethTx := range ethTxs {
 		msg := &evmtypes.MsgEthereumTx{}
-		msg.FromEthereumTx(ethTx)
-
-		txBuilder := app.txConfig.NewTxBuilder()
-		if err := txBuilder.SetMsgs(msg); err != nil {
-			return fmt.Errorf("failed to set msg in tx builder: %w", err)
+		ethSigner := ethtypes.LatestSigner(evmtypes.GetEthChainConfig())
+		if err := msg.FromSignedEthereumTx(ethTx, ethSigner); err != nil {
+			return fmt.Errorf("failed to convert ethereum transaction: %w", err)
 		}
 
-		txBytes, err := app.txConfig.TxEncoder()(txBuilder.GetTx())
+		cosmosTx, err := msg.BuildTx(app.clientCtx.TxConfig.NewTxBuilder(), "akii")
+		if err != nil {
+			return fmt.Errorf("failed to build cosmos tx: %w", err)
+		}
+
+		txBytes, err := app.clientCtx.TxConfig.TxEncoder()(cosmosTx)
 		if err != nil {
 			return fmt.Errorf("failed to encode transaction: %w", err)
 		}
@@ -64,7 +67,7 @@ func (app *KiichainApp) broadcastEVMTransactions(ethTxs []*ethtypes.Transaction)
 		if err != nil {
 			return fmt.Errorf("failed to broadcast transaction %s: %w", ethTx.Hash().Hex(), err)
 		}
-		if res.Code != 0 {
+		if res.Code != 0 && res.Code != 19 {
 			return fmt.Errorf("transaction %s rejected by mempool: code=%d, log=%s", ethTx.Hash().Hex(), res.Code, res.RawLog)
 		}
 	}

--- a/tests/e2e/e2e_evm_test.go
+++ b/tests/e2e/e2e_evm_test.go
@@ -9,7 +9,6 @@ import (
 	"math/big"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -104,52 +103,53 @@ func (s *IntegrationTestSuite) testEVM(jsonRPC string) {
 	})
 }
 
-// testMempoolEVM Tests EVM's mempool
-func (s *IntegrationTestSuite) testMempoolEVM(jsonRPC string) {
-	var err error
+// Disabled until EVM mempool is enabled again
+// // testMempoolEVM Tests EVM's mempool
+// func (s *IntegrationTestSuite) testMempoolEVM(jsonRPC string) {
+// 	var err error
 
-	// Get a funded EVM account and check balance transactions
-	evmAccount := s.chainA.evmAccount
+// 	// Get a funded EVM account and check balance transactions
+// 	evmAccount := s.chainA.evmAccount
 
-	// Setup client
-	client, err := ethclient.Dial(jsonRPC)
-	s.Require().NoError(err)
+// 	// Setup client
+// 	client, err := ethclient.Dial(jsonRPC)
+// 	s.Require().NoError(err)
 
-	// Get the nonce (transaction count)
-	nonce, err := client.PendingNonceAt(context.Background(), evmAccount.address)
-	s.Require().NoError(err)
+// 	// Get the nonce (transaction count)
+// 	nonce, err := client.PendingNonceAt(context.Background(), evmAccount.address)
+// 	s.Require().NoError(err)
 
-	// Setup send amt
-	amount := big.NewInt(1000000)
+// 	// Setup send amt
+// 	amount := big.NewInt(1000000)
 
-	// Test Mempool
-	s.Run("Testing out of order nonce", func() {
-		// Send 3 Txs with nonce
-		// Nonce +0
-		tx, err := EVMSendWithNonce(client, evmAccount.key, evmAccount.address, s.chainB.evmAccount.address, amount, nil, nonce)
-		s.Require().NoError(err)
+// 	// Test Mempool
+// 	s.Run("Testing out of order nonce", func() {
+// 		// Send 3 Txs with nonce
+// 		// Nonce +0
+// 		tx, err := EVMSendWithNonce(client, evmAccount.key, evmAccount.address, s.chainB.evmAccount.address, amount, nil, nonce)
+// 		s.Require().NoError(err)
 
-		// Nonce +2
-		tx2, err := EVMSendWithNonce(client, evmAccount.key, evmAccount.address, s.chainB.evmAccount.address, amount, nil, nonce+2)
-		s.Require().NoError(err)
+// 		// Nonce +2
+// 		tx2, err := EVMSendWithNonce(client, evmAccount.key, evmAccount.address, s.chainB.evmAccount.address, amount, nil, nonce+2)
+// 		s.Require().NoError(err)
 
-		// Wait to make sure it is in the correct ordering
-		time.Sleep(time.Millisecond * 500)
+// 		// Wait to make sure it is in the correct ordering
+// 		time.Sleep(time.Millisecond * 500)
 
-		// Nonce +1
-		tx3, err := EVMSendWithNonce(client, evmAccount.key, evmAccount.address, s.chainB.evmAccount.address, amount, nil, nonce+1)
-		s.Require().NoError(err)
+// 		// Nonce +1
+// 		tx3, err := EVMSendWithNonce(client, evmAccount.key, evmAccount.address, s.chainB.evmAccount.address, amount, nil, nonce+1)
+// 		s.Require().NoError(err)
 
-		// Wait for successful first tx
-		s.waitForTransaction(client, tx, evmAccount.address)
+// 		// Wait for successful first tx
+// 		s.waitForTransaction(client, tx, evmAccount.address)
 
-		// Wait for successful third tx
-		s.waitForTransaction(client, tx3, evmAccount.address)
+// 		// Wait for successful third tx
+// 		s.waitForTransaction(client, tx3, evmAccount.address)
 
-		// Wait for successful second tx
-		s.waitForTransaction(client, tx2, evmAccount.address)
-	})
-}
+// 		// Wait for successful second tx
+// 		s.waitForTransaction(client, tx2, evmAccount.address)
+// 	})
+// }
 
 // waitForTransaction waits until transaction is mined, requiring its success and checks reason in case of failure
 func (s *IntegrationTestSuite) waitForTransaction(client *ethclient.Client, tx *geth.Transaction, sender common.Address) *geth.Receipt {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -163,7 +163,8 @@ func (s *IntegrationTestSuite) TestEVM() {
 	jsonRPC := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("8545/tcp"))
 	s.testEVMQueries(jsonRPC)
 	s.testEVM(jsonRPC)
-	s.testMempoolEVM(jsonRPC)
+	// Disabled until mempool bug is fixed
+	// s.testMempoolEVM(jsonRPC)
 }
 
 // TestERC20 runs the ERC20 tests. It is skipped if the variable is set

--- a/tests/integration/failing-tests.md
+++ b/tests/integration/failing-tests.md
@@ -26,7 +26,7 @@ Test requires `network.WithBaseCoin("akii", 18)`
 Requires unsealed config.
 
 ## Mempool
-Complains of not being accessible.
+About 70% pass, but 30% do cosmos transactions using fee as Aatom.
 
 ## Gov
 On `TestGovPrecompileTestSuite`:


### PR DESCRIPTION
# Description

The EVM mempool is currently bugged, its broadcast failing to public nodes.
The workarounds we tried only led to further issues in the broadcasting.

## Type of change

- [x] Bugfix


# How Has This Been Tested?

unit and e2e tests
