### PR TITLE
Remove math.sqrt from ballot calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixed
 
 - Disable EVM mempool due to bug on public nodes broadcast
+- Remove unsafe math.Sqrt usage in oracle ballot standard deviation calculation
 
 ## v6.0.0 - 2025-11-25
 

--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -1,10 +1,7 @@
 package types
 
 import (
-	"fmt"
-	"math"
 	"sort"
-	"strconv"
 
 	sdkMath "cosmossdk.io/math"
 
@@ -182,12 +179,14 @@ func (ex ExchangeRateBallot) StandardDeviation(median sdkMath.LegacyDec) (standa
 		sum = sum.Add(deviation.Mul(deviation))     // Calculate sum += (ex - median)^2
 	}
 
-	variance := sum.QuoInt64(int64(len(ex))) // Divide the result by the number of ex
+	// Divide the result by the number of ex
+	variance := sum.QuoInt64(int64(len(ex)))
 
-	floatNum, _ := strconv.ParseFloat(variance.String(), 64)
-	floatNum = math.Sqrt(floatNum)
-
-	standardDeviation, _ = sdkMath.LegacyNewDecFromStr(fmt.Sprintf("%f", floatNum))
+	// Finally get the square root of variance
+	standardDeviation, err := variance.ApproxSqrt()
+	if err != nil {
+		return sdkMath.LegacyZeroDec()
+	}
 
 	return
 }

--- a/x/oracle/types/ballot_test.go
+++ b/x/oracle/types/ballot_test.go
@@ -179,7 +179,12 @@ func TestStandardDeviation(t *testing.T) {
 	// Calculate the standard deviation
 	median := ballot.WeightedMedianWithAssertion()
 	deviation := ballot.StandardDeviation(median)
-	require.Equal(t, sdkMath.LegacyNewDecWithPrec(1224745, 6), deviation)
+
+	expected := sdkMath.LegacyNewDecWithPrec(1224745, 6)
+	// 2e-7 tolerance
+	delta := sdkMath.LegacyNewDecWithPrec(2, 7)
+
+	require.True(t, deviation.Sub(expected).Abs().LTE(delta))
 }
 
 func TestToCrossRate(t *testing.T) {


### PR DESCRIPTION
# Description

This removes the unsafe math.sqrt from ballot calculation.
This solves issue #188 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Tests are passing
