### PR TITLE
fix: Oracle EndBlocker: Unhandled panic in pickReferenceDenom can cause consensus failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed dead code related to no gas consumption
 
 ## Fixed
+- Handle error in pickReferenceDenom instead of panic to prevent chain halt [#203](https://github.com/KiiChain/kiichain/issues/203)
 
 - Disable EVM mempool due to bug on public nodes broadcast
 - Remove references to time.Now() on release schedule validation
@@ -45,6 +46,7 @@
 -   Bump [EVM](github.com/cosmos/evm) to [v0.4.2](https://github.com/cosmos/evm/releases/tag/v0.4.2)
 
 ## Fixed
+- Handle error in pickReferenceDenom instead of panic to prevent chain halt [#203](https://github.com/KiiChain/kiichain/issues/203)
 
 - Fix IBC unsafe log as reported on issue [#143](https://github.com/KiiChain/kiichain/issues/143)
 - Fix wasmd precompile bad input handling for coins [#147](https://github.com/KiiChain/kiichain/issues/147)

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -75,7 +75,11 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 		if err != nil {
 			return err
 		}
-		referenceDenom, belowThresholdVoteMap := pickReferenceDenom(ctx, k, voteTargets, voteMap)
+		referenceDenom, belowThresholdVoteMap, err := pickReferenceDenom(ctx, k, voteTargets, voteMap)
+		if err != nil {
+			ctx.Logger().Error("failed to pick reference denom", "error", err)
+			return err
+		}
 
 		if referenceDenom != "" {
 			ballotRD := voteMap[referenceDenom] // get the ballot of the RD

--- a/x/oracle/tally.go
+++ b/x/oracle/tally.go
@@ -12,7 +12,7 @@ import (
 // pickReferenceDenom selects a denom with the highest vote power as reference denom.
 // If the power of 2 denominations is the same, select the reference denom
 // in alphabetical order
-func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string]types.Denom, voteMap map[string]types.ExchangeRateBallot) (string, map[string]types.ExchangeRateBallot) {
+func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string]types.Denom, voteMap map[string]types.ExchangeRateBallot) (string, map[string]types.ExchangeRateBallot, error) {
 	highestBallotPower := int64(0)
 	referenceDenom := ""
 	belowThresholdVoteMap := map[string]types.ExchangeRateBallot{}
@@ -25,7 +25,7 @@ func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string
 	// Get threshold (minimum power necessary to considerate a successful ballot)
 	params, err := k.Params.Get(ctx)
 	if err != nil {
-		panic(err)
+		return "", nil, err
 	}
 
 	voteThreshold := params.VoteThreshold                                 // Get vote threshold from params
@@ -64,7 +64,7 @@ func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string
 			referenceDenom = denom
 		}
 	}
-	return referenceDenom, belowThresholdVoteMap
+	return referenceDenom, belowThresholdVoteMap, nil
 }
 
 // ballotIsPassing calculate the sum of each vote power per denom, then check

--- a/x/oracle/tally_test.go
+++ b/x/oracle/tally_test.go
@@ -97,7 +97,7 @@ func TestPickReferenceDenom(t *testing.T) {
 	}
 
 	// Must return denom atomDenom and kiiBallot as below threshold map
-	referenceDenom, belowThresholdVoteMap := pickReferenceDenom(ctx, oracleKeeper, votingTarget, voteMap)
+	referenceDenom, belowThresholdVoteMap, _ := pickReferenceDenom(ctx, oracleKeeper, votingTarget, voteMap)
 	require.Equal(t, utils.AtomDenom, referenceDenom)
 	require.Equal(t, expectedBelowThreshold, belowThresholdVoteMap)
 }


### PR DESCRIPTION
## [BUG] Oracle EndBlocker: Unhandled panic in pickReferenceDenom can cause consensus failure

## Bug Description

Found a panic in the oracle module that can cause chain halt. The `pickReferenceDenom` function is called from EndBlocker, and contains an unhandled `panic(err)`.

Location: `x/oracle/tally.go`

```go
params, err := k.Params.Get(ctx)
if err != nil {
    panic(err)
}
```

The `pickReferenceDenom` function is called from `EndBlocker` in `x/oracle/abci.go`:

```go
referenceDenom, belowThresholdVoteMap := pickReferenceDenom(ctx, k, voteTargets, voteMap)
```

This is dangerous - panic in a function called from an ABCI method (EndBlocker) will crash all validators on the same block.

---

## Attack Flow

```
EndBlocker called every block
    → pickReferenceDenom(ctx, k, voteTargets, voteMap)
        → k.Params.Get(ctx) returns error
        → panic(err)
        → ALL VALIDATORS CRASH
        → CHAIN HALT
```

Conditions that cause `Params.Get()` to error:
- State corruption
- Storage issues
- Migration failure

---

## Environment

- File: `x/oracle/tally.go` line 28
- Function: `pickReferenceDenom()`
- Called from: `x/oracle/abci.go` EndBlocker

---

## Impact

Severity: Critical

- Consensus failure: Yes - all validators crash on the same block
- Chain halt: Yes - requires coordinated restart

Similar bugs:
- Informal Systems audit Gravity Bridge: https://github.com/althea-net/cosmos-gravity-bridge/issues/348
- Sherlock audit Allora (High severity): https://github.com/sherlock-audit/2024-06-allora-judging/issues/21

---

## Fix

Return error instead of panic:

```go
// Before
params, err := k.Params.Get(ctx)
if err != nil {
    panic(err)
}

// After
params, err := k.Params.Get(ctx)
if err != nil {
    return "", nil, err
}
```

---

## Full Fix Files

### File 1: `x/oracle/tally.go` (MODIFIED)

Change function signature to return error and replace panic with return:

```go
func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string]types.Denom, voteMap map[string]types.ExchangeRateBallot) (string, map[string]types.ExchangeRateBallot, error) {
    // ... existing code ...

    params, err := k.Params.Get(ctx)
    if err != nil {
        return "", nil, err
    }

    // ... existing code ...

    return referenceDenom, belowThresholdVoteMap, nil
}
```

### File 2: `x/oracle/abci.go` (MODIFIED)

Update caller to handle error:

```go
referenceDenom, belowThresholdVoteMap, err := pickReferenceDenom(ctx, k, voteTargets, voteMap)
if err != nil {
    return err
}
```

### File 3: `x/oracle/tally_test.go` (MODIFIED)

Update test to handle new return value:

```go
referenceDenom, belowThresholdVoteMap, _ := pickReferenceDenom(ctx, oracleKeeper, votingTarget, voteMap)
```

### Test Result (After Fix)

```
=== RUN   TestPickReferenceDenom
--- PASS: TestPickReferenceDenom (0.01s)
PASS
ok      github.com/kiichain/kiichain/v7/x/oracle        0.091s
```
