### PR TITLE
fix(oracle): handle errors in pickReferenceDenom instead of panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed dead code related to no gas consumption
 
 ## Fixed
+- Handle ignored error from TotalBondedTokens in pickReferenceDenom [#230](https://github.com/KiiChain/kiichain/issues/230)
 - Handle error in pickReferenceDenom instead of panic to prevent consensus failure [#203](https://github.com/KiiChain/kiichain/issues/203)
 
 - Disable EVM mempool due to bug on public nodes broadcast
@@ -46,6 +47,7 @@
 -   Bump [EVM](github.com/cosmos/evm) to [v0.4.2](https://github.com/cosmos/evm/releases/tag/v0.4.2)
 
 ## Fixed
+- Handle ignored error from TotalBondedTokens in pickReferenceDenom [#230](https://github.com/KiiChain/kiichain/issues/230)
 
 - Fix IBC unsafe log as reported on issue [#143](https://github.com/KiiChain/kiichain/issues/143)
 - Fix wasmd precompile bad input handling for coins [#147](https://github.com/KiiChain/kiichain/issues/147)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@
 -   Bump [EVM](github.com/cosmos/evm) to [v0.4.2](https://github.com/cosmos/evm/releases/tag/v0.4.2)
 
 ## Fixed
-- Handle ignored error from TotalBondedTokens in pickReferenceDenom [#230](https://github.com/KiiChain/kiichain/issues/230)
 
 - Fix IBC unsafe log as reported on issue [#143](https://github.com/KiiChain/kiichain/issues/143)
 - Fix wasmd precompile bad input handling for coins [#147](https://github.com/KiiChain/kiichain/issues/147)

--- a/x/oracle/tally.go
+++ b/x/oracle/tally.go
@@ -18,8 +18,12 @@ func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string
 	belowThresholdVoteMap := map[string]types.ExchangeRateBallot{}
 
 	// Get total bonded power
-	powerReductionFactor := k.StakingKeeper.PowerReduction(ctx)                             // get the power reduction
-	totalBondedTokens, _ := k.StakingKeeper.TotalBondedTokens(ctx)                          // total of tokens in staking
+	powerReductionFactor := k.StakingKeeper.PowerReduction(ctx)      // get the power reduction
+	totalBondedTokens, err := k.StakingKeeper.TotalBondedTokens(ctx) // total of tokens in staking
+	if err != nil {
+		ctx.Logger().Error("failed to get total bonded tokens in pickReferenceDenom", "error", err)
+		return "", nil, err
+	}
 	totalBondedPower := sdk.TokensToConsensusPower(totalBondedTokens, powerReductionFactor) // Get the blockchain vote power
 
 	// Get threshold (minimum power necessary to considerate a successful ballot)

--- a/x/oracle/tally.go
+++ b/x/oracle/tally.go
@@ -18,8 +18,8 @@ func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string
 	belowThresholdVoteMap := map[string]types.ExchangeRateBallot{}
 
 	// Get total bonded power
-	powerReductionFactor := k.StakingKeeper.PowerReduction(ctx)      // get the power reduction
-	totalBondedTokens, err := k.StakingKeeper.TotalBondedTokens(ctx) // total of tokens in staking
+	powerReductionFactor := k.StakingKeeper.PowerReduction(ctx)                             // get the power reduction
+	totalBondedTokens, err := k.StakingKeeper.TotalBondedTokens(ctx)                        // total of tokens in staking
 	if err != nil {
 		ctx.Logger().Error("failed to get total bonded tokens in pickReferenceDenom", "error", err)
 		return "", nil, err

--- a/x/oracle/tally.go
+++ b/x/oracle/tally.go
@@ -18,8 +18,8 @@ func pickReferenceDenom(ctx sdk.Context, k keeper.Keeper, voteTargets map[string
 	belowThresholdVoteMap := map[string]types.ExchangeRateBallot{}
 
 	// Get total bonded power
-	powerReductionFactor := k.StakingKeeper.PowerReduction(ctx)                             // get the power reduction
-	totalBondedTokens, err := k.StakingKeeper.TotalBondedTokens(ctx)                        // total of tokens in staking
+	powerReductionFactor := k.StakingKeeper.PowerReduction(ctx)      // get the power reduction
+	totalBondedTokens, err := k.StakingKeeper.TotalBondedTokens(ctx) // total of tokens in staking
 	if err != nil {
 		ctx.Logger().Error("failed to get total bonded tokens in pickReferenceDenom", "error", err)
 		return "", nil, err

--- a/x/oracle/tally_test.go
+++ b/x/oracle/tally_test.go
@@ -1,6 +1,8 @@
 package oracle
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -217,6 +219,43 @@ func TestPickReferenceDenomError(t *testing.T) {
 	referenceDenom, belowThresholdVoteMap, err := pickReferenceDenom(ctx, oracleKeeper, votingTarget, voteMap)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "collections")
+	require.Empty(t, referenceDenom)
+	require.Nil(t, belowThresholdVoteMap)
+}
+
+// MockStakingKeeperError is a mock that returns error for TotalBondedTokens
+type MockStakingKeeperError struct {
+	types.StakingKeeper
+}
+
+func (m MockStakingKeeperError) TotalBondedTokens(ctx context.Context) (math.Int, error) {
+	return math.Int{}, fmt.Errorf("mock error: failed to get total bonded tokens")
+}
+
+func (m MockStakingKeeperError) PowerReduction(ctx context.Context) math.Int {
+	return sdk.DefaultPowerReduction
+}
+
+func TestPickReferenceDenomTotalBondedTokensError(t *testing.T) {
+	input := keeper.CreateTestInput(t)
+	oracleKeeper := input.OracleKeeper
+	ctx := input.Ctx
+
+	// Replace StakingKeeper with mock that returns error
+	oracleKeeper.StakingKeeper = MockStakingKeeperError{}
+
+	// Create minimal voting targets and vote map
+	votingTarget := map[string]types.Denom{
+		utils.AtomDenom: {Name: utils.AtomDenom},
+	}
+	voteMap := map[string]types.ExchangeRateBallot{
+		utils.AtomDenom: {},
+	}
+
+	// pickReferenceDenom should return error when TotalBondedTokens fails
+	referenceDenom, belowThresholdVoteMap, err := pickReferenceDenom(ctx, oracleKeeper, votingTarget, voteMap)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mock error")
 	require.Empty(t, referenceDenom)
 	require.Nil(t, belowThresholdVoteMap)
 }

--- a/x/oracle/tally_test.go
+++ b/x/oracle/tally_test.go
@@ -228,14 +228,17 @@ type MockStakingKeeperError struct {
 	types.StakingKeeper
 }
 
+// TotalBondedTokens returns an error to simulate staking keeper failure.
 func (m MockStakingKeeperError) TotalBondedTokens(ctx context.Context) (math.Int, error) {
 	return math.Int{}, fmt.Errorf("mock error: failed to get total bonded tokens")
 }
 
+// PowerReduction returns the default power reduction value.
 func (m MockStakingKeeperError) PowerReduction(ctx context.Context) math.Int {
 	return sdk.DefaultPowerReduction
 }
 
+// TestPickReferenceDenomTotalBondedTokensError verifies that pickReferenceDenom returns an error when TotalBondedTokens fails.
 func TestPickReferenceDenomTotalBondedTokensError(t *testing.T) {
 	input := keeper.CreateTestInput(t)
 	oracleKeeper := input.OracleKeeper


### PR DESCRIPTION
# fix(oracle): handle errors in pickReferenceDenom instead of panic

- Handle error from TotalBondedTokens instead of ignoring with `_`
- Return error from Params.Get instead of panic
- Update pickReferenceDenom signature to return error
- Update caller in abci.go to handle the error

Fixes #230

## Description

In `x/oracle/tally.go`, the `pickReferenceDenom` function has two error handling issues:

1. Line 22: Error from `TotalBondedTokens()` is ignored with `_`
2. Line 28: Error from `Params.Get()` causes panic instead of returning error

This PR restructures `pickReferenceDenom` to return an error to the oracle EndBlocker, as suggested by maintainer @Thaleszh.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Code review - verified error handling logic
- [x] Checked that function signature change propagates correctly to caller in abci.go
