### PR TITLE
Make fee conversion rounding explicit (always round up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed dead code related to no gas consumption
 
 ## Fixed
+- Make ERC20 fee conversion rounding explicit by always rounding up to avoid underpayment
 - Handle ignored error from TotalBondedTokens in pickReferenceDenom [#230](https://github.com/KiiChain/kiichain/issues/230)
 - Handle error in pickReferenceDenom instead of panic to prevent consensus failure [#203](https://github.com/KiiChain/kiichain/issues/203)
 

--- a/x/feeabstraction/keeper/fee.go
+++ b/x/feeabstraction/keeper/fee.go
@@ -109,8 +109,8 @@ func (k Keeper) convertERC20ForFees(ctx sdk.Context, account sdk.AccAddress, fee
 		if err != nil {
 			return sdk.Coins{}, math.LegacyDec{}, err
 		}
-		// Truncate the decimals
-		amountEquivalentInt := amountEquivalent.RoundInt()
+		// Round up to avoid fee underpayment
+		amountEquivalentInt := amountEquivalent.Ceil().TruncateInt()
 		// If the amount is zero, we skip this fee token
 		if amountEquivalentInt.IsZero() {
 			continue


### PR DESCRIPTION
## Description

This PR makes the ERC20 fee conversion rounding behavior explicit and conservative.

Previously, the code used:

```go
amountEquivalentInt := amountEquivalent.RoundInt()
```
RoundInt() uses bankers rounding, which can round up or down depending on the value.
For fee calculation paths, this can theoretically allow very small underpayment in edge cases.
This PR changes the logic to always round up:
```
amountEquivalentInt := amountEquivalent.Ceil().TruncateInt()
```
This guarantees that:

- Fee payment is never under-collected
- Rounding behavior is explicit and deterministic
- Behavior is conservative and safe for fee accounting

The economic difference is negligible (at most 1 unit of smallest denomination), but this removes ambiguity and makes the policy clear.

Related discussion: [#227](https://github.com/KiiChain/kiichain/issues/227)