### PR TITLE
fix(oracle): handle ValAddressFromBech32 error in EndBlocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ## Fixed
 - Make ERC20 fee conversion rounding explicit by always rounding up to avoid underpayment
+- Handle ValAddressFromBech32 error in oracle EndBlocker [#234](https://github.com/KiiChain/kiichain/issues/234)
 - Handle ignored error from TotalBondedTokens in pickReferenceDenom [#230](https://github.com/KiiChain/kiichain/issues/230)
 - Handle error in pickReferenceDenom instead of panic to prevent consensus failure [#203](https://github.com/KiiChain/kiichain/issues/203)
 

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -53,7 +53,11 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 				operator := validator.GetOperator()                     // Get address to receive coins
 
 				// Parse the operator address
-				operatorAddr, _ := sdk.ValAddressFromBech32(operator)
+				operatorAddr, err := sdk.ValAddressFromBech32(operator)
+				if err != nil {
+					ctx.Logger().Error("failed to parse operator address", "operator", operator, "error", err)
+					continue
+				}
 
 				claim := types.NewClaim(valPower, 0, 0, false, operatorAddr) // Create claim object
 				validatorClaimMap[operator] = claim                          // Assign the validator on the list to receive


### PR DESCRIPTION
**Severity:** LOW  
**File:** `x/oracle/abci.go`  
**Line:** 56  
**Repository:** https://github.com/KiiChain/kiichain  
**Version:** v6.1.0  
**Commit:** `79bdc96`  
**Issue:** https://github.com/KiiChain/kiichain/issues/234  
**PR:** https://github.com/KiiChain/kiichain/pull/240  
**Auditor:** ngapaxs  
**Date:** 2025-01-19  

---

## Summary

Found an ignored error in the oracle module's EndBlocker. When parsing validator addresses fails, the code just ignores it with `_`, which means that validator gets skipped silently.

---

## Affected Code

```go
if validator.IsBonded() {
    valPower := validator.GetConsensusPower(powerReduction)
    operator := validator.GetOperator()
    operatorAddr, _ := sdk.ValAddressFromBech32(operator)  // error ignored here
    claim := types.NewClaim(valPower, 0, 0, false, operatorAddr)
    validatorClaimMap[operator] = claim
}
```

---

## Root Cause

The error from `ValAddressFromBech32` gets ignored with `_`. If parsing fails, `operatorAddr` ends up nil and the claim gets an invalid recipient.

---

## Impact

- Validators that fail to parse just get skipped
- Their delegation power doesn't count in the vote
- Voting power ends up wrong (missing some validators)
- Runs every vote period so this could happen often

---

## Recommended Fix

```go
operatorAddr, err := sdk.ValAddressFromBech32(operator)
if err != nil {
    ctx.Logger().Error("failed to parse operator address", "operator", operator, "error", err)
    continue
}
```

Just log the error and skip that validator. Don't return error because that could let malicious validators disable the whole module.

---

## Reference

https://github.com/KiiChain/kiichain/blob/v6.1.0/x/oracle/abci.go#L56