### PR TITLE
fix(oracle): use original voteTargets count for success check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Removed ICS precompile
 
 ## Fixed
-- Fix oracle weighted median threshold to require >50% instead of >=50% for majority
+- Fix oracle validator success count using original voteTargets size before pickReferenceDenom modifies the map [#237](https://github.com/KiiChain/kiichain/issues/237)
 - Make ERC20 fee conversion rounding explicit by always rounding up to avoid underpayment
 - Handle ValAddressFromBech32 error in oracle EndBlocker [#234](https://github.com/KiiChain/kiichain/issues/234)
 - Handle ignored error from TotalBondedTokens in pickReferenceDenom [#230](https://github.com/KiiChain/kiichain/issues/230)

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -79,6 +79,10 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 		if err != nil {
 			return err
 		}
+
+		// Store original vote target count before pickReferenceDenom modifies the map
+		originalVoteTargetCount := len(voteTargets)
+
 		referenceDenom, belowThresholdVoteMap, err := pickReferenceDenom(ctx, k, voteTargets, voteMap)
 		if err != nil {
 			return err
@@ -143,7 +147,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 
 		// Validate miss voting process
 		for _, claim := range validatorClaimMap {
-			if int(claim.WinCount) == len(voteTargets) {
+			if int(claim.WinCount) == originalVoteTargetCount {
 				err = k.IncrementSuccessCount(ctx, claim.Recipient)
 				if err != nil {
 					return err

--- a/x/oracle/success_count_test.go
+++ b/x/oracle/success_count_test.go
@@ -1,0 +1,63 @@
+package oracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/math"
+
+	"github.com/kiichain/kiichain/v7/x/oracle/keeper"
+	"github.com/kiichain/kiichain/v7/x/oracle/types"
+	"github.com/kiichain/kiichain/v7/x/oracle/utils"
+)
+
+func TestValidatorSuccessCountWithBelowThresholdDenoms(t *testing.T) {
+	t.Run("Validator votes all denoms", func(t *testing.T) {
+		input, _ := SetUp(t)
+		ctx := input.Ctx.WithBlockHeight(1)
+		oracleKeeper := input.OracleKeeper
+
+		params, err := oracleKeeper.Params.Get(ctx)
+		require.NoError(t, err)
+
+		params.VotePeriod = 1
+		err = oracleKeeper.Params.Set(ctx, params)
+		require.NoError(t, err)
+
+		voteTargets := []string{utils.AtomDenom, utils.EthDenom, utils.KiiDenom}
+		for _, denom := range voteTargets {
+			err := oracleKeeper.VoteTarget.Set(ctx, denom, types.Denom{Name: denom})
+			require.NoError(t, err)
+		}
+
+		valOperator := keeper.ValAddrs[0]
+
+		vote, err := types.NewAggregateExchangeRateVote(
+			types.ExchangeRateTuples{
+				{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDecWithPrec(100, 2)},
+				{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDecWithPrec(100, 2)},
+				{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDecWithPrec(100, 2)},
+			},
+			valOperator,
+		)
+		require.NoError(t, err)
+
+		err = oracleKeeper.AggregateExchangeRateVote.Set(ctx, valOperator, vote)
+		require.NoError(t, err)
+
+		initialCounter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, valOperator)
+		if err != nil {
+			initialCounter = types.NewVotePenaltyCounter(0, 0, 0)
+		}
+		initialSuccessCount := initialCounter.SuccessCount
+
+		err = EndBlocker(ctx, oracleKeeper)
+		require.NoError(t, err)
+
+		finalCounter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, valOperator)
+		require.NoError(t, err)
+
+		require.Greater(t, finalCounter.SuccessCount, initialSuccessCount, "should get success count")
+	})
+}

--- a/x/oracle/success_count_test.go
+++ b/x/oracle/success_count_test.go
@@ -2,62 +2,46 @@ package oracle
 
 import (
 	"testing"
-
 	"github.com/stretchr/testify/require"
-
 	"cosmossdk.io/math"
-
 	"github.com/kiichain/kiichain/v7/x/oracle/keeper"
 	"github.com/kiichain/kiichain/v7/x/oracle/types"
-	"github.com/kiichain/kiichain/v7/x/oracle/utils"
 )
 
 func TestValidatorSuccessCountWithBelowThresholdDenoms(t *testing.T) {
-	t.Run("Validator votes all denoms", func(t *testing.T) {
-		input, _ := SetUp(t)
-		ctx := input.Ctx.WithBlockHeight(1)
-		oracleKeeper := input.OracleKeeper
-
-		params, err := oracleKeeper.Params.Get(ctx)
-		require.NoError(t, err)
-
-		params.VotePeriod = 1
-		err = oracleKeeper.Params.Set(ctx, params)
-		require.NoError(t, err)
-
-		voteTargets := []string{utils.AtomDenom, utils.EthDenom, utils.KiiDenom}
-		for _, denom := range voteTargets {
-			err := oracleKeeper.VoteTarget.Set(ctx, denom, types.Denom{Name: denom})
-			require.NoError(t, err)
-		}
-
-		valOperator := keeper.ValAddrs[0]
-
-		vote, err := types.NewAggregateExchangeRateVote(
-			types.ExchangeRateTuples{
-				{Denom: utils.AtomDenom, ExchangeRate: math.LegacyNewDecWithPrec(100, 2)},
-				{Denom: utils.EthDenom, ExchangeRate: math.LegacyNewDecWithPrec(100, 2)},
-				{Denom: utils.KiiDenom, ExchangeRate: math.LegacyNewDecWithPrec(100, 2)},
-			},
-			valOperator,
-		)
-		require.NoError(t, err)
-
-		err = oracleKeeper.AggregateExchangeRateVote.Set(ctx, valOperator, vote)
-		require.NoError(t, err)
-
-		initialCounter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, valOperator)
-		if err != nil {
-			initialCounter = types.NewVotePenaltyCounter(0, 0, 0)
-		}
-		initialSuccessCount := initialCounter.SuccessCount
-
-		err = EndBlocker(ctx, oracleKeeper)
-		require.NoError(t, err)
-
-		finalCounter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, valOperator)
-		require.NoError(t, err)
-
-		require.Greater(t, finalCounter.SuccessCount, initialSuccessCount, "should get success count")
-	})
+	input, _ := SetUp(t)
+	ctx := input.Ctx.WithBlockHeight(1)
+	k := input.OracleKeeper
+	
+	k.VoteTarget.Set(ctx, "atom", types.Denom{Name: "atom"})
+	k.VoteTarget.Set(ctx, "eth", types.Denom{Name: "eth"})
+	k.VoteTarget.Set(ctx, "usdt", types.Denom{Name: "usdt"})
+	
+	valAddr := keeper.ValAddrs[0]
+	vote, _ := types.NewAggregateExchangeRateVote(
+		types.ExchangeRateTuples{
+			{Denom: "atom", ExchangeRate: math.LegacyNewDec(100)},
+			{Denom: "eth", ExchangeRate: math.LegacyNewDec(100)},
+			{Denom: "usdt", ExchangeRate: math.LegacyNewDec(100)},
+		},
+		valAddr,
+	)
+	k.AggregateExchangeRateVote.Set(ctx, valAddr, vote)
+	
+	initialCounter := types.NewVotePenaltyCounter(0, 0, 0)
+	k.VotePenaltyCounter.Set(ctx, valAddr, initialCounter)
+	
+	params, _ := k.Params.Get(ctx)
+	params.VoteThreshold = math.LegacyNewDecWithPrec(99, 2)
+	params.VotePeriod = 1
+	k.Params.Set(ctx, params)
+	
+	initial, _ := k.VotePenaltyCounter.Get(ctx, valAddr)
+	initialSuccess := initial.SuccessCount
+	
+	EndBlocker(ctx, k)
+	
+	final, _ := k.VotePenaltyCounter.Get(ctx, valAddr)
+	
+	require.Greater(t, final.SuccessCount, initialSuccess)
 }


### PR DESCRIPTION
# Description

Bug in oracle module - success counting logic is backwards.

The issue: `pickReferenceDenom` deletes denoms from `voteTargets` map, but later we check `len(voteTargets)` for success. Since the map got smaller, the check fails for validators who actually voted correctly.

Example: 5 denoms in whitelist, validator votes for all 5. Two denoms fail threshold and get deleted. Map now has 3. Validator has WinCount=5 but check is `5 == 3` = fail. Gets miss count even though they voted for everything.

Fix: save `len(voteTargets)` before calling `pickReferenceDenom`, use that saved value for the success check instead.

Fixes #237

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Checked the code flow - confirmed that voteTargets map gets modified by pickReferenceDenom before the success check runs. With this fix, we store the count first so the check uses the right number.

- [x] Code review

# PR Checklist:

- [x] Updated changelog with PR's intent
- [ ] Lint with `make lint-fix`