### PR TITLE
fix(oracle): use ConsensusVersion constant instead of hardcoded value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed ICS precompile
 
 ## Fixed
+- Fixed oracle module ConsensusVersion constant not being used ([#256](https://github.com/KiiChain/kiichain/issues/256))
 - Fix oracle weighted median threshold to require >50% instead of >=50% for majority
 - Make ERC20 fee conversion rounding explicit by always rounding up to avoid underpayment
 - Handle ValAddressFromBech32 error in oracle EndBlocker [#234](https://github.com/KiiChain/kiichain/issues/234)

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -28,7 +28,7 @@ var (
 )
 
 // ConsensusVersion defines the current x/oracle module consensus version.
-const ConsensusVersion = 1
+const ConsensusVersion = 6
 
 // ----------------------------------------------------------------------------
 // AppModuleBasic
@@ -165,7 +165,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion returns the version the module's version
-func (AppModule) ConsensusVersion() uint64 { return 6 }
+func (AppModule) ConsensusVersion() uint64 { return ConsensusVersion }
 
 // BeginBlock returns the begin blocker for the oracle module.
 func (am AppModule) BeginBlock(ctx context.Context) error {


### PR DESCRIPTION
# Description

Found this weird bug in oracle module. There's a constant `ConsensusVersion = 1` defined but it's never used anywhere. The function just returns hardcoded `6` instead.

**The problem:**
- Line 31: `const ConsensusVersion = 1` (just sitting there doing nothing)
- Line 168: `func (AppModule) ConsensusVersion() uint64 { return 6 }` (why hardcode this?)

**What I changed:**
- Updated the constant from 1 to 6 (so it matches what the function should return)
- Made the function actually use the constant instead of hardcoding

Now it's consistent with other modules like tokenfactory, rewards, and feeabstraction that properly use their ConsensusVersion constants.

Fixes #256

## Type of change

- [x] Bug fix (code quality improvement)

# How Has This Been Tested?

- [x] Checked that constant now matches what function returns
- [x] Built successfully, no issues
- [x] Compared with other modules to make sure it's consistent

# Checklist:

- [x] Added to changelog
- [x] Follows same pattern as other modules