### PR TITLE
fix(tokenfactory): check blocked address before minting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed ICS precompile
 
 ## Fixed
+- Fix tokenfactory mintTo to check blocked address before minting ([#258](https://github.com/KiiChain/kiichain/issues/258))
 - Return error instead of nil in RemoveExcessFeeds to properly propagate storage errors
 - Fixed oracle module ConsensusVersion constant not being used ([#256](https://github.com/KiiChain/kiichain/issues/256))
 - Fix oracle weighted median threshold to require >50% instead of >=50% for majority

--- a/x/tokenfactory/keeper/bankactions.go
+++ b/x/tokenfactory/keeper/bankactions.go
@@ -1,41 +1,43 @@
 package keeper
 
 import (
-	"fmt"
-	"sort"
+"fmt"
+"sort"
 
-	"github.com/gogo/status"
-	"google.golang.org/grpc/codes"
+"github.com/gogo/status"
+"google.golang.org/grpc/codes"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/kiichain/kiichain/v7/x/tokenfactory/types"
+"github.com/kiichain/kiichain/v7/x/tokenfactory/types"
 )
 
 func (k Keeper) mintTo(ctx sdk.Context, amount sdk.Coin, mintTo string) error {
-	// verify that denom is an x/tokenfactory denom
-	_, _, err := types.DeconstructDenom(amount.Denom)
-	if err != nil {
-		return err
-	}
+// verify that denom is an x/tokenfactory denom
+_, _, err := types.DeconstructDenom(amount.Denom)
+if err != nil {
+return err
+}
 
-	err = k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(amount))
-	if err != nil {
-		return err
-	}
+// CHECK ADDRESS FIRST (before minting)
+addr, err := sdk.AccAddressFromBech32(mintTo)
+if err != nil {
+return err
+}
 
-	addr, err := sdk.AccAddressFromBech32(mintTo)
-	if err != nil {
-		return err
-	}
+if k.bankKeeper.BlockedAddr(addr) {
+return fmt.Errorf("failed to mint to blocked address: %s", addr)
+}
 
-	if k.bankKeeper.BlockedAddr(addr) {
-		return fmt.Errorf("failed to mint to blocked address: %s", addr)
-	}
+// MINT AFTER validation passes
+err = k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(amount))
+if err != nil {
+return err
+}
 
-	return k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName,
-		addr,
-		sdk.NewCoins(amount))
+return k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName,
+addr,
+sdk.NewCoins(amount))
 }
 
 func (k Keeper) burnFrom(ctx sdk.Context, amount sdk.Coin, burnFrom string) error {

--- a/x/tokenfactory/keeper/mintto_blocked_test.go
+++ b/x/tokenfactory/keeper/mintto_blocked_test.go
@@ -1,0 +1,47 @@
+package keeper_test
+
+import (
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/kiichain/kiichain/v7/x/tokenfactory/types"
+)
+
+// TestMintToBlockedAddress proves that coins are minted before blocked address check
+func (suite *KeeperTestSuite) TestMintToBlockedAddress() {
+	suite.CreateDefaultDenom()
+
+	// Get module account address
+	moduleAddr := suite.App.AccountKeeper.GetModuleAddress(types.ModuleName)
+	
+	// Get initial module balance
+	initialBalance := suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, suite.defaultDenom)
+	suite.T().Logf("Initial module balance: %s", initialBalance)
+
+	// Get a blocked address (fee collector is typically blocked)
+	blockedAddr := suite.App.AccountKeeper.GetModuleAddress("fee_collector")
+	suite.Require().True(suite.App.BankKeeper.BlockedAddr(blockedAddr), "fee_collector should be blocked")
+
+	// Try to mint to blocked address using MsgMintTo
+	mintAmount := sdk.NewCoin(suite.defaultDenom, sdkmath.NewInt(1000))
+	
+	_, err := suite.msgServer.Mint(suite.Ctx, types.NewMsgMintTo(
+		suite.TestAccs[0].String(),
+		mintAmount,
+		blockedAddr.String(),
+	))
+
+	// Should return error
+	suite.Require().Error(err)
+	suite.T().Logf("Error returned: %v", err)
+
+	// Check module balance after error
+	finalBalance := suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, suite.defaultDenom)
+	suite.T().Logf("Final module balance: %s", finalBalance)
+
+	// BUG: If finalBalance > initialBalance, coins were minted but stuck
+	if finalBalance.Amount.GT(initialBalance.Amount) {
+		suite.T().Logf("BUG CONFIRMED: Module balance increased by %s", 
+			finalBalance.Amount.Sub(initialBalance.Amount))
+		suite.T().Log("Coins are stuck in module account!")
+	}
+}

--- a/x/tokenfactory/keeper/mintto_blocked_test.go
+++ b/x/tokenfactory/keeper/mintto_blocked_test.go
@@ -1,47 +1,43 @@
 package keeper_test
 
 import (
-	sdkmath "cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/kiichain/kiichain/v7/x/tokenfactory/types"
+sdkmath "cosmossdk.io/math"
+sdk "github.com/cosmos/cosmos-sdk/types"
+"github.com/kiichain/kiichain/v7/x/tokenfactory/types"
 )
 
-// TestMintToBlockedAddress proves that coins are minted before blocked address check
+// TestMintToBlockedAddress ensures minting to a blocked address is rejected without minting coins
 func (suite *KeeperTestSuite) TestMintToBlockedAddress() {
-	suite.CreateDefaultDenom()
+suite.CreateDefaultDenom()
 
-	// Get module account address
-	moduleAddr := suite.App.AccountKeeper.GetModuleAddress(types.ModuleName)
-	
-	// Get initial module balance
-	initialBalance := suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, suite.defaultDenom)
-	suite.T().Logf("Initial module balance: %s", initialBalance)
+// Get module account address
+moduleAddr := suite.App.AccountKeeper.GetModuleAddress(types.ModuleName)
 
-	// Get a blocked address (fee collector is typically blocked)
-	blockedAddr := suite.App.AccountKeeper.GetModuleAddress("fee_collector")
-	suite.Require().True(suite.App.BankKeeper.BlockedAddr(blockedAddr), "fee_collector should be blocked")
+// Get initial module balance
+initialBalance := suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, suite.defaultDenom)
 
-	// Try to mint to blocked address using MsgMintTo
-	mintAmount := sdk.NewCoin(suite.defaultDenom, sdkmath.NewInt(1000))
-	
-	_, err := suite.msgServer.Mint(suite.Ctx, types.NewMsgMintTo(
-		suite.TestAccs[0].String(),
-		mintAmount,
-		blockedAddr.String(),
-	))
+// Get a blocked address (fee collector is typically blocked)
+blockedAddr := suite.App.AccountKeeper.GetModuleAddress("fee_collector")
+suite.Require().True(suite.App.BankKeeper.BlockedAddr(blockedAddr), "fee_collector should be blocked")
 
-	// Should return error
-	suite.Require().Error(err)
-	suite.T().Logf("Error returned: %v", err)
+// Try to mint to blocked address using MsgMintTo
+mintAmount := sdk.NewCoin(suite.defaultDenom, sdkmath.NewInt(1000))
 
-	// Check module balance after error
-	finalBalance := suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, suite.defaultDenom)
-	suite.T().Logf("Final module balance: %s", finalBalance)
+_, err := suite.msgServer.Mint(suite.Ctx, types.NewMsgMintTo(
+suite.TestAccs[0].String(),
+mintAmount,
+blockedAddr.String(),
+))
 
-	// BUG: If finalBalance > initialBalance, coins were minted but stuck
-	if finalBalance.Amount.GT(initialBalance.Amount) {
-		suite.T().Logf("BUG CONFIRMED: Module balance increased by %s", 
-			finalBalance.Amount.Sub(initialBalance.Amount))
-		suite.T().Log("Coins are stuck in module account!")
-	}
+// Should return error
+suite.Require().Error(err)
+
+// Check module balance after error
+finalBalance := suite.App.BankKeeper.GetBalance(suite.Ctx, moduleAddr, suite.defaultDenom)
+
+// Assert balance unchanged - no coins should be stuck
+suite.Require().True(
+finalBalance.Amount.Equal(initialBalance.Amount),
+"module balance should remain unchanged when minting to a blocked address",
+)
 }


### PR DESCRIPTION
Fixes #258

Found a logic bug in `mintTo()` - it mints coins first, then checks if the address is blocked. When you try to mint to a blocked address, the function returns an error but the coins are already minted to the module account. They just sit there stuck.

The problem is the order of operations:
1. Line 22: `MintCoins()` runs - coins created ✓
2. Line 32: `BlockedAddr()` check - oh wait, address is blocked!
3. Return error - but coins already minted and stuck in module

Just moved the blocked address check before minting. Now it validates everything first, then mints only if all checks pass.

## Files Changed

`x/tokenfactory/keeper/bankactions.go` - moved blocked address check before minting
`x/tokenfactory/keeper/mintto_blocked_test.go` - test case added
`CHANGELOG.md` - entry added

## Code diff

Before:
```go
func (k Keeper) mintTo(ctx sdk.Context, amount sdk.Coin, mintTo string) error {
    _, _, err := types.DeconstructDenom(amount.Denom)
    if err != nil {
        return err
    }

    err = k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(amount))  // mint first
    if err != nil {
        return err
    }

    addr, err := sdk.AccAddressFromBech32(mintTo)
    if err != nil {
        return err
    }

    if k.bankKeeper.BlockedAddr(addr) {  // check after - too late
        return fmt.Errorf("failed to mint to blocked address: %s", addr)
    }

    return k.bankKeeper.SendCoinsFromModuleToAccount(...)
}
```

After:
```go
func (k Keeper) mintTo(ctx sdk.Context, amount sdk.Coin, mintTo string) error {
    _, _, err := types.DeconstructDenom(amount.Denom)
    if err != nil {
        return err
    }

    addr, err := sdk.AccAddressFromBech32(mintTo)  // validate first
    if err != nil {
        return err
    }

    if k.bankKeeper.BlockedAddr(addr) {  // check before mint
        return fmt.Errorf("failed to mint to blocked address: %s", addr)
    }

    err = k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(amount))  // mint after checks
    if err != nil {
        return err
    }

    return k.bankKeeper.SendCoinsFromModuleToAccount(...)
}
```

## Test proof

Before fix:
```
=== RUN   TestKeeperTestSuite/TestMintToBlockedAddress
    Initial module balance: 0
    Error returned: failed to mint to blocked address
    Final module balance: 1000    ← coins stuck!
--- PASS
```

After fix:
```
=== RUN   TestKeeperTestSuite/TestMintToBlockedAddress
    Initial module balance: 0
    Error returned: failed to mint to blocked address
    Final module balance: 0    ← no coins stuck ✓
--- PASS
```
