### PR TITLE
Deprecate config flag for evm chain ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Pick evm-chaind-id from genesis instead of config / flag
+- Pick evm-chain-id from genesis instead of config / flag
 
 ## v7.0.0 - 2026-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
-## UNRELEASED
+## v7.0.1 - 2026-02-11
+
+### Fixed
+
+- Pick evm-chaind-id from genesis instead of config / flag
+
+## v7.0.0 - 2026-02-03
 
 ## Dependencies
 - Bump Go version from 1.23 to 1.24

--- a/app/config.go
+++ b/app/config.go
@@ -88,7 +88,7 @@ func ParseChainID(chainID string) (uint64, error) {
 
 	matches := fullChainID.FindStringSubmatch(chainID)
 	if matches == nil || len(matches) != 4 || matches[1] == "" {
-		return 0, fmt.Errorf("chain-id '%s' does not match expected chain ID format: %s_%s-%s", chainID, regexChainID, regexEIP155, regexEpoch)
+		return 0, fmt.Errorf("chain-id '%s' does not match expected chain ID format: <chain name>_<evm chain id>-<epoch separator>, like localhost_1010-1", chainID)
 	}
 
 	// verify that the EIP155 part (matches[2]) is a base 10 integer

--- a/app/config.go
+++ b/app/config.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/spf13/viper"
-
 	clienthelpers "cosmossdk.io/client/v2/helpers"
 
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
@@ -72,28 +70,6 @@ func init() {
 					KiichainID = evmChainID
 					return
 				}
-				// If parsing fails, continue to check app.toml
-			}
-		}
-	}
-	if err != nil && !os.IsNotExist(err) {
-		panic(err)
-	}
-
-	// If genesis file does not exist or chain ID is not found, check app.toml
-	// to get the EVM chain ID
-	appTomlPath := filepath.Join(nodeHome, "config", "app.toml")
-	if _, err = os.Stat(appTomlPath); err == nil {
-		// File exists
-		v := viper.New()
-		v.SetConfigFile(appTomlPath)
-		v.SetConfigType("toml")
-
-		if err = v.ReadInConfig(); err == nil {
-			evmChainIDKey := "evm.evm-chain-id"
-			if v.IsSet(evmChainIDKey) {
-				evmChainID := v.GetUint64(evmChainIDKey)
-				KiichainID = evmChainID
 			}
 		}
 	}

--- a/cmd/kiichaind/cmd/init.go
+++ b/cmd/kiichaind/cmd/init.go
@@ -28,6 +28,7 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 
+	kiichain "github.com/kiichain/kiichain/v7/app"
 	"github.com/kiichain/kiichain/v7/app/params"
 )
 
@@ -92,6 +93,12 @@ func initCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			default:
 				// This has a custom configuration to respect the Eth chains
 				chainID = fmt.Sprintf("test_1234-%d", unsafe.Int())
+			}
+
+			// Validate chain ID has evm counterpart
+			_, err := kiichain.ParseChainID(chainID)
+			if err != nil {
+				return err
 			}
 
 			// Get bip39 mnemonic and recover

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -427,7 +427,7 @@ func (a appCreator) newApp(
 	evmChainIdFlag := cast.ToUint64(viperAppOpts.Get(srvflags.EVMChainID))
 	// Warn if flag is not default
 	if evmChainIdFlag != evmserverconfig.DefaultEVMChainID {
-		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d. Remove it from the start command and the from '.kiichaind/config/app.toml' to remove warning.",
+		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is deprecrated. The evm chain ID is being overridden to %d. Remove it from the start command and the from '.kiichaind/config/app.toml' to remove warning.",
 			srvflags.EVMChainID, kiichain.KiichainID))
 	}
 

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -421,8 +421,8 @@ func (a appCreator) newApp(
 	evmChainIdFlag := cast.ToUint64(viperAppOpts.Get(srvflags.EVMChainID))
 	// Warn if flag is not default
 	if evmChainIdFlag != 262144 {
-		fmt.Fprintf(os.Stderr, "WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d.\n",
-			srvflags.EVMChainID, kiichain.KiichainID)
+		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d.\n",
+			srvflags.EVMChainID, kiichain.KiichainID))
 	}
 
 	viperAppOpts.Set(srvflags.EVMChainID, kiichain.KiichainID)

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -426,7 +426,7 @@ func (a appCreator) newApp(
 
 	evmChainIdFlag := cast.ToUint64(viperAppOpts.Get(srvflags.EVMChainID))
 	// Warn if flag is not default
-	if evmChainIdFlag != 262144 {
+	if evmChainIdFlag != evmserverconfig.DefaultEVMChainID {
 		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d.\n",
 			srvflags.EVMChainID, kiichain.KiichainID))
 	}

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -418,6 +418,13 @@ func (a appCreator) newApp(
 		panic("appOpts is not viper.Viper")
 	}
 
+	evmChainIdFlag := cast.ToUint64(viperAppOpts.Get(srvflags.EVMChainID))
+	// Warn if flag is not default
+	if evmChainIdFlag != 262144 {
+		fmt.Fprintf(os.Stderr, "WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d.\n",
+			srvflags.EVMChainID, kiichain.KiichainID)
+	}
+
 	viperAppOpts.Set(srvflags.EVMChainID, kiichain.KiichainID)
 
 	return kiichain.NewKiichainApp(

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -427,7 +427,7 @@ func (a appCreator) newApp(
 	evmChainIdFlag := cast.ToUint64(viperAppOpts.Get(srvflags.EVMChainID))
 	// Warn if flag is not default
 	if evmChainIdFlag != evmserverconfig.DefaultEVMChainID {
-		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d. Remove it from the start command and the from '.kiichaind/config/app.toml' to remove warning.\n",
+		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d. Remove it from the start command and the from '.kiichaind/config/app.toml' to remove warning.",
 			srvflags.EVMChainID, kiichain.KiichainID))
 	}
 

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -384,6 +384,12 @@ func (a appCreator) newApp(
 		panic(err)
 	}
 
+	// Validate chain ID has evm counterpart
+	_, err = kiichain.ParseChainID(chainID)
+	if err != nil {
+		panic(err)
+	}
+
 	snapshotDir := filepath.Join(homeDir, "data", "snapshots")
 	snapshotDB, err := dbm.NewDB("metadata", server.GetAppDBBackend(appOpts), snapshotDir)
 	if err != nil {

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -427,7 +427,7 @@ func (a appCreator) newApp(
 	evmChainIdFlag := cast.ToUint64(viperAppOpts.Get(srvflags.EVMChainID))
 	// Warn if flag is not default
 	if evmChainIdFlag != evmserverconfig.DefaultEVMChainID {
-		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d.\n",
+		logger.Warn(fmt.Sprintf("WARNING: The --%s flag is depecrated. The evm chain ID is being overridden to %d. Remove it from the start command and the from '.kiichaind/config/app.toml' to remove warning.\n",
 			srvflags.EVMChainID, kiichain.KiichainID))
 	}
 

--- a/cmd/kiichaind/cmd/root.go
+++ b/cmd/kiichaind/cmd/root.go
@@ -418,11 +418,7 @@ func (a appCreator) newApp(
 		panic("appOpts is not viper.Viper")
 	}
 
-	existingValue := viperAppOpts.Get(srvflags.EVMChainID)
-	// Check if value exists
-	if existingValue == nil || existingValue == "" {
-		viperAppOpts.Set(srvflags.EVMChainID, kiichain.KiichainID)
-	}
+	viperAppOpts.Set(srvflags.EVMChainID, kiichain.KiichainID)
 
 	return kiichain.NewKiichainApp(
 		logger,


### PR DESCRIPTION
# Description

Deprecates the usage of evm chain id via flat or config, always picking it up from the genesis

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

pipelines and locally

# PR Checklist:

Make sure each step was done:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
