### PR TITLE
feat: re-enable jailing on oracle module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## UNRELEASED
+
+### Added
+
+- Re enabled jailing on oracle module
+
+### Fixed
+
+- Fixed misbehaviors on oracle module slashing
+
 ## v7.0.1 - 2026-02-11
 
 ### Fixed

--- a/tests/e2e/e2e_oracle_test.go
+++ b/tests/e2e/e2e_oracle_test.go
@@ -132,9 +132,10 @@ func (s *IntegrationTestSuite) testSlash() {
 	queryPenaltyCounter, err := queryPenaltyCounter(chainEndpoint, validatorAddress)
 	s.Require().NoError(err, "failed to query penalty counter for validator %s", validatorAddress)
 
-	// Both the success and the abstain votes should be above zero
+	// Success votes should be above zero
 	s.Require().Greater(queryPenaltyCounter.VotePenaltyCounter.SuccessCount, uint64(0), "success penalty counter should be greater than zero")
-	s.Require().Greater(queryPenaltyCounter.VotePenaltyCounter.AbstainCount, uint64(0), "abstain penalty counter should be greater than zero")
+	// Abstain should be zero since there is no voting
+	s.Require().Equal(queryPenaltyCounter.VotePenaltyCounter.AbstainCount, uint64(0), "abstain penalty counter should be greater than zero")
 }
 
 // checkAndUpdateOracleParams checks if the oracle parameters are set correctly and updates them if necessary

--- a/tests/e2e/e2e_oracle_test.go
+++ b/tests/e2e/e2e_oracle_test.go
@@ -135,7 +135,7 @@ func (s *IntegrationTestSuite) testSlash() {
 	// Success votes should be above zero
 	s.Require().Greater(queryPenaltyCounter.VotePenaltyCounter.SuccessCount, uint64(0), "success penalty counter should be greater than zero")
 	// Abstain should be zero since there is no voting
-	s.Require().Equal(queryPenaltyCounter.VotePenaltyCounter.AbstainCount, uint64(0), "abstain penalty counter should be greater than zero")
+	s.Require().Equal(queryPenaltyCounter.VotePenaltyCounter.AbstainCount, uint64(0), "abstain penalty counter should be zero")
 }
 
 // checkAndUpdateOracleParams checks if the oracle parameters are set correctly and updates them if necessary

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -157,7 +157,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 
 		// Validate miss voting process
 		for _, claim := range validatorClaimMap {
-			if int(claim.WinCount) >= len(voteTargets) {
+			if int(claim.WinCount) == len(voteTargets) {
 				err = k.IncrementSuccessCount(ctx, claim.Recipient)
 				if err != nil {
 					return err

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -141,6 +141,14 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 			Tally(ctx, ballot, params.RewardBand, validatorClaimMap)
 		}
 
+		// Remove any VoteTarget that did not have any vote
+		for denom := range voteTargets {
+			_, inVoteMap := voteMap[denom]
+			if !inVoteMap {
+				delete(voteTargets, denom)
+			}
+		}
+
 		// Validate miss voting process
 		for _, claim := range validatorClaimMap {
 			if int(claim.WinCount) == len(voteTargets) {

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -232,7 +232,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) error {
 		return err
 	}
 
-	// Slash who did miss voting over threshold
+	// Slash and jail who did miss voting over threshold
 	// reset miss counter of all validators at the last block of slash window
 	if utils.IsPeriodLastBlock(ctx, params.SlashWindow) {
 		err = k.SlashAndResetCounters(ctx) // slash and jail validator then reset voting counter

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -138,7 +138,12 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 		// Calculate tally for below threshold assets lists
 		for _, denom := range belowThresholdDenoms {
 			ballot := belowThresholdVoteMap[denom]
-			Tally(ctx, ballot, params.RewardBand, validatorClaimMap)
+			// Make a discardable map for belowThreshold votes, so tally changes don't affect scoring
+			discardableClaimMap := make(map[string]types.Claim, len(validatorClaimMap))
+			for k, v := range validatorClaimMap {
+				discardableClaimMap[k] = v
+			}
+			Tally(ctx, ballot, params.RewardBand, discardableClaimMap)
 		}
 
 		// Remove any VoteTarget that did not have any vote
@@ -230,6 +235,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	// Slash who did miss voting over threshold
 	// reset miss counter of all validators at the last block of slash window
 	if utils.IsPeriodLastBlock(ctx, params.SlashWindow) {
+		// Add jail back in repeated offence
 		err = k.SlashAndResetCounters(ctx) // slash validator and reset voting counter
 		if err != nil {
 			return err

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -3,6 +3,8 @@ package oracle
 import (
 	"sort"
 
+	metrics "github.com/hashicorp/go-metrics"
+
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -143,6 +145,16 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 			}
 		}
 
+		// Emit telemetry for all denoms excluded from price aggregation
+		sort.Strings(excludedDenoms)
+		for _, denom := range excludedDenoms {
+			telemetry.SetGaugeWithLabels(
+				[]string{types.ModuleName, "excluded_denom"},
+				1,
+				[]metrics.Label{telemetry.NewLabel("denom", denom)},
+			)
+		}
+
 		// Validate miss voting process
 		for _, claim := range validatorClaimMap {
 			if int(claim.WinCount) >= len(voteTargets) {
@@ -210,6 +222,18 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	return nil
 }
 
+// writeValidatorPenaltyMetrics emits telemetry gauges for each validator's miss,
+// abstain, and success counts before the slash window resets them.
+func writeValidatorPenaltyMetrics(ctx sdk.Context, k keeper.Keeper) error {
+	return k.VotePenaltyCounter.Walk(ctx, nil, func(operator sdk.ValAddress, counter types.VotePenaltyCounter) (bool, error) {
+		labels := []metrics.Label{telemetry.NewLabel("validator", operator.String())}
+		telemetry.SetGaugeWithLabels([]string{types.ModuleName, "miss_count"}, float32(counter.MissCount), labels)
+		telemetry.SetGaugeWithLabels([]string{types.ModuleName, "abstain_count"}, float32(counter.AbstainCount), labels)
+		telemetry.SetGaugeWithLabels([]string{types.ModuleName, "success_count"}, float32(counter.SuccessCount), labels)
+		return false, nil
+	})
+}
+
 // BeginBlocker is the function that slashes the validators and resets the miss counters
 func BeginBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	// Apply telemetry metrics
@@ -224,6 +248,11 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	// Slash and jail who did miss voting over threshold
 	// reset miss counter of all validators at the last block of slash window
 	if utils.IsPeriodLastBlock(ctx, params.SlashWindow) {
+		err = writeValidatorPenaltyMetrics(ctx, k) // emit telemetry for successes and misses
+		if err != nil {
+			return err
+		}
+
 		err = k.SlashAndResetCounters(ctx) // slash and jail validator then reset voting counter
 		if err != nil {
 			return err

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -128,28 +128,17 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 			}
 		}
 
-		// Extract the denoms stored on belowThresholdVote map
-		belowThresholdDenoms := make([]string, 0, len(belowThresholdVoteMap))
+		// Collect all denoms excluded from aggregation: below threshold and no votes
+		excludedDenoms := make([]string, 0, len(belowThresholdVoteMap))
 		for denom := range belowThresholdVoteMap {
-			belowThresholdDenoms = append(belowThresholdDenoms, denom)
-		}
-		sort.Strings(belowThresholdDenoms) // sort by denom name
-
-		// Calculate tally for below threshold assets lists
-		for _, denom := range belowThresholdDenoms {
-			ballot := belowThresholdVoteMap[denom]
-			// Make a discardable map for belowThreshold votes, so tally changes don't affect scoring
-			discardableClaimMap := make(map[string]types.Claim, len(validatorClaimMap))
-			for k, v := range validatorClaimMap {
-				discardableClaimMap[k] = v
-			}
-			Tally(ctx, ballot, params.RewardBand, discardableClaimMap)
+			excludedDenoms = append(excludedDenoms, denom)
 		}
 
-		// Remove any VoteTarget that did not have any vote
+		// Remove any VoteTarget that did not have any vote, collecting them as well
 		for denom := range voteTargets {
 			_, inVoteMap := voteMap[denom]
 			if !inVoteMap {
+				excludedDenoms = append(excludedDenoms, denom)
 				delete(voteTargets, denom)
 			}
 		}

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -235,8 +235,7 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	// Slash who did miss voting over threshold
 	// reset miss counter of all validators at the last block of slash window
 	if utils.IsPeriodLastBlock(ctx, params.SlashWindow) {
-		// Add jail back in repeated offence
-		err = k.SlashAndResetCounters(ctx) // slash validator and reset voting counter
+		err = k.SlashAndResetCounters(ctx) // slash and jail validator then reset voting counter
 		if err != nil {
 			return err
 		}

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -151,7 +151,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 
 		// Validate miss voting process
 		for _, claim := range validatorClaimMap {
-			if int(claim.WinCount) == len(voteTargets) {
+			if int(claim.WinCount) >= len(voteTargets) {
 				err = k.IncrementSuccessCount(ctx, claim.Recipient)
 				if err != nil {
 					return err

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -414,4 +414,230 @@ func TestEndblocker(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+
+	t.Run("No votes submitted - Exchange rate should not be stored", func(t *testing.T) {
+		// Reset blockchain state
+		input, _ := SetUp(t)
+		ctx := input.Ctx
+		oracleKeeper := input.OracleKeeper
+
+		// Set a single vote target
+		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
+		require.NoError(t, err)
+
+		ctx = input.Ctx.WithBlockHeight(1)
+
+		// No validators submit votes — skip directly to end/begin blocker
+
+		err = EndBlocker(ctx, oracleKeeper)
+		require.NoError(t, err)
+
+		// No exchange rate should have been stored since nobody voted
+		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.AtomDenom)
+		require.Error(t, err)
+
+		// Check if all three are getting abstain counts
+		for i := 0; i < 3; i++ {
+			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
+			require.NoError(t, err)
+			require.EqualValues(t, uint64(1), counter.AbstainCount)
+		}
+	})
+
+	t.Run("All validators miss one out of four denom votes - Miss count should increase for all", func(t *testing.T) {
+		// Reset blockchain state
+		input, msgServer := SetUp(t)
+		ctx := input.Ctx
+		oracleKeeper := input.OracleKeeper
+
+		// Set four vote targets: atom, eth, kii and usdc
+		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.KiiDenom, types.Denom{Name: utils.KiiDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.UsdcDenom, types.Denom{Name: utils.UsdcDenom})
+		require.NoError(t, err)
+
+		ctx = input.Ctx.WithBlockHeight(1)
+
+		// All validators vote for atom, eth and kii — skipping usdc entirely
+		partialRate := randomAExchangeRate.String() + utils.AtomDenom +
+			"," + randomAExchangeRate.String() + utils.EthDenom +
+			"," + randomAExchangeRate.String() + utils.KiiDenom
+		for i := 0; i < 3; i++ {
+			voteMsg := types.NewMsgAggregateExchangeRateVote(partialRate, keeper.Addrs[i], keeper.ValAddrs[i])
+			_, err := msgServer.AggregateExchangeRateVote(ctx, voteMsg)
+			require.NoError(t, err)
+		}
+
+		err = EndBlocker(ctx, oracleKeeper)
+		require.NoError(t, err)
+
+		// Atom, eth and kii should be stored normally since all validators voted for them
+		for _, denom := range []string{utils.AtomDenom, utils.EthDenom, utils.KiiDenom} {
+			exchangeRateResponse, err := oracleKeeper.ExchangeRate.Get(ctx, denom)
+			require.NoError(t, err)
+			require.Equal(t, randomAExchangeRate, exchangeRateResponse.ExchangeRate)
+		}
+
+		// Usdc should not be stored since nobody voted for it
+		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.UsdcDenom)
+		require.Error(t, err)
+
+		// All validators should have a miss count of 1 since none of them
+		// achieved a WinCount equal to the total number of vote targets (4)
+		for i := 0; i < 3; i++ {
+			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
+			require.NoError(t, err)
+			require.EqualValues(t, uint64(1), counter.MissCount)
+			require.EqualValues(t, uint64(0), counter.AbstainCount)
+		}
+	})
+
+	t.Run("One denom below threshold - validators who voted for it still miss", func(t *testing.T) {
+		// Reset blockchain state
+		input, msgServer := SetUp(t)
+		ctx := input.Ctx
+		oracleKeeper := input.OracleKeeper
+
+		// Set four vote targets: atom, eth, kii and usdc
+		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.KiiDenom, types.Denom{Name: utils.KiiDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.UsdcDenom, types.Denom{Name: utils.UsdcDenom})
+		require.NoError(t, err)
+
+		ctx = input.Ctx.WithBlockHeight(1)
+
+		// All 3 validators vote for atom, eth and kii (above threshold)
+		// Only validator 0 votes for usdc — keeping it below the ballot threshold
+		fullRate := randomAExchangeRate.String() + utils.AtomDenom +
+			"," + randomAExchangeRate.String() + utils.EthDenom +
+			"," + randomAExchangeRate.String() + utils.KiiDenom +
+			"," + randomAExchangeRate.String() + utils.UsdcDenom
+		partialRate := randomAExchangeRate.String() + utils.AtomDenom +
+			"," + randomAExchangeRate.String() + utils.EthDenom +
+			"," + randomAExchangeRate.String() + utils.KiiDenom
+
+		// Validator 0 votes for all four denoms (including usdc)
+		voteMsg := types.NewMsgAggregateExchangeRateVote(fullRate, keeper.Addrs[0], keeper.ValAddrs[0])
+		_, err = msgServer.AggregateExchangeRateVote(ctx, voteMsg)
+		require.NoError(t, err)
+
+		// Validators 1 and 2 skip usdc, keeping it below threshold
+		for i := 1; i < 3; i++ {
+			voteMsg := types.NewMsgAggregateExchangeRateVote(partialRate, keeper.Addrs[i], keeper.ValAddrs[i])
+			_, err := msgServer.AggregateExchangeRateVote(ctx, voteMsg)
+			require.NoError(t, err)
+		}
+
+		err = EndBlocker(ctx, oracleKeeper)
+		require.NoError(t, err)
+
+		// Atom, eth and kii should be stored — they passed the ballot threshold
+		for _, denom := range []string{utils.AtomDenom, utils.EthDenom, utils.KiiDenom} {
+			exchangeRateResponse, err := oracleKeeper.ExchangeRate.Get(ctx, denom)
+			require.NoError(t, err)
+			require.Equal(t, randomAExchangeRate, exchangeRateResponse.ExchangeRate)
+		}
+
+		// Usdc should not be stored — it failed the ballot threshold
+		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.UsdcDenom)
+		require.Error(t, err)
+
+		// Validators 1 and 2 voted for 3 out of 3 valid targets — their WinCount (3)
+		// will match len(voteTargets) (3), so they get a success
+		for i := 1; i < 3; i++ {
+			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
+			require.NoError(t, err)
+			require.EqualValues(t, uint64(0), counter.MissCount)
+			require.EqualValues(t, uint64(0), counter.AbstainCount)
+		}
+
+		// Validator 0 voted for all 4 denoms. Usdc went to belowThresholdVoteMap
+		// and still runs through Tally, so validator 0 gets WinCount=4 and
+		// does not matches len(voteTargets) — earning a miss
+		counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[0])
+		require.NoError(t, err)
+		require.EqualValues(t, uint64(1), counter.MissCount)
+		require.EqualValues(t, uint64(0), counter.AbstainCount)
+	})
+
+	t.Run("Validator hits below-threshold denom but deviates on an above-threshold one - should miss", func(t *testing.T) {
+		// Reset blockchain state
+		input, msgServer := SetUp(t)
+		ctx := input.Ctx
+		oracleKeeper := input.OracleKeeper
+
+		// Set four vote targets: atom, eth, kii and usdc
+		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.EthDenom, types.Denom{Name: utils.EthDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.KiiDenom, types.Denom{Name: utils.KiiDenom})
+		require.NoError(t, err)
+		err = oracleKeeper.VoteTarget.Set(ctx, utils.UsdcDenom, types.Denom{Name: utils.UsdcDenom})
+		require.NoError(t, err)
+
+		ctx = input.Ctx.WithBlockHeight(1)
+
+		// Validators 1 and 2 vote correctly on atom, eth and kii — skipping usdc
+		// keeping it below threshold
+		partialRate := randomAExchangeRate.String() + utils.AtomDenom +
+			"," + randomAExchangeRate.String() + utils.EthDenom +
+			"," + randomAExchangeRate.String() + utils.KiiDenom
+		for i := 1; i < 3; i++ {
+			voteMsg := types.NewMsgAggregateExchangeRateVote(partialRate, keeper.Addrs[i], keeper.ValAddrs[i])
+			_, err := msgServer.AggregateExchangeRateVote(ctx, voteMsg)
+			require.NoError(t, err)
+		}
+
+		// Validator 0 deviates heavily on eth but votes correctly on usdc
+		// (which will land in belowThresholdVoteMap since only val 0 voted for it)
+		deviatedRate := randomAExchangeRate.String() + utils.AtomDenom +
+			"," + aboveExchangeRate.String() + utils.EthDenom +
+			"," + randomAExchangeRate.String() + utils.KiiDenom +
+			"," + randomAExchangeRate.String() + utils.UsdcDenom
+		voteMsg := types.NewMsgAggregateExchangeRateVote(deviatedRate, keeper.Addrs[0], keeper.ValAddrs[0])
+		_, err = msgServer.AggregateExchangeRateVote(ctx, voteMsg)
+		require.NoError(t, err)
+
+		err = EndBlocker(ctx, oracleKeeper)
+		require.NoError(t, err)
+
+		// Atom, eth and kii should be stored based on validators 1 and 2 votes
+		for _, denom := range []string{utils.AtomDenom, utils.EthDenom, utils.KiiDenom} {
+			exchangeRateResponse, err := oracleKeeper.ExchangeRate.Get(ctx, denom)
+			require.NoError(t, err)
+			require.Equal(t, randomAExchangeRate, exchangeRateResponse.ExchangeRate)
+		}
+
+		// Usdc should not be stored — only validator 0 voted, below threshold
+		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.UsdcDenom)
+		require.Error(t, err)
+
+		// Validators 1 and 2 voted correctly on all 3 above-threshold denoms
+		// WinCount == 3 == len(voteTargets) → success
+		// Validator 0 voted incorrectly on Eth, but correctly on under threshold
+		// So WinCount == 3 as well
+		for i := 0; i < 3; i++ {
+			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
+			require.NoError(t, err)
+			require.EqualValues(t, uint64(0), counter.MissCount)
+			require.EqualValues(t, uint64(0), counter.AbstainCount)
+		}
+	})
 }

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -320,6 +320,10 @@ func TestEndblocker(t *testing.T) {
 		slashedPower := validator.GetConsensusPower(stakingKeeper.PowerReduction(ctx))
 		require.True(t, slashedPower < 10)
 
+		// Validator should now be jailed
+		require.NoError(t, err)
+		require.True(t, validator.IsJailed())
+
 		// Check voting info deleted
 		result, err := oracleKeeper.VotePenaltyCounter.Get(ctx, operator)
 		require.Empty(t, result)

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -630,13 +630,18 @@ func TestEndblocker(t *testing.T) {
 
 		// Validators 1 and 2 voted correctly on all 3 above-threshold denoms
 		// WinCount == 3 == len(voteTargets) → success
-		// Validator 0 voted incorrectly on Eth, but correctly on under threshold
-		// It should get a miss since it only got one success
-		for i := 0; i < 3; i++ {
+		for i := 1; i < 3; i++ {
 			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
 			require.NoError(t, err)
-			require.EqualValues(t, uint64(1), counter.MissCount)
+			require.EqualValues(t, uint64(0), counter.MissCount)
 			require.EqualValues(t, uint64(0), counter.AbstainCount)
 		}
+
+		// Validator 0 voted incorrectly on Eth, but correctly on under threshold
+		// It should get a miss since it only got one success
+		counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[0])
+		require.NoError(t, err)
+		require.EqualValues(t, uint64(1), counter.MissCount)
+		require.EqualValues(t, uint64(0), counter.AbstainCount)
 	})
 }

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -624,18 +624,18 @@ func TestEndblocker(t *testing.T) {
 			require.Equal(t, randomAExchangeRate, exchangeRateResponse.ExchangeRate)
 		}
 
-		// Usdc should not be stored — only validator 0 voted, below threshold
+		// Usdc should not be stored, only validator 0 voted, below threshold
 		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.UsdcDenom)
 		require.Error(t, err)
 
 		// Validators 1 and 2 voted correctly on all 3 above-threshold denoms
 		// WinCount == 3 == len(voteTargets) → success
 		// Validator 0 voted incorrectly on Eth, but correctly on under threshold
-		// So WinCount == 3 as well
+		// It should get a miss since it only got one success
 		for i := 0; i < 3; i++ {
 			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
 			require.NoError(t, err)
-			require.EqualValues(t, uint64(0), counter.MissCount)
+			require.EqualValues(t, uint64(1), counter.MissCount)
 			require.EqualValues(t, uint64(0), counter.AbstainCount)
 		}
 	})

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -415,7 +415,7 @@ func TestEndblocker(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("No votes submitted - Exchange rate should not be stored", func(t *testing.T) {
+	t.Run("No votes submitted - Exchange rate should not be stored, no one should be penalized", func(t *testing.T) {
 		// Reset blockchain state
 		input, _ := SetUp(t)
 		ctx := input.Ctx
@@ -429,8 +429,7 @@ func TestEndblocker(t *testing.T) {
 
 		ctx = input.Ctx.WithBlockHeight(1)
 
-		// No validators submit votes — skip directly to end/begin blocker
-
+		// Run endblock
 		err = EndBlocker(ctx, oracleKeeper)
 		require.NoError(t, err)
 
@@ -438,21 +437,22 @@ func TestEndblocker(t *testing.T) {
 		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.AtomDenom)
 		require.Error(t, err)
 
-		// Check if all three are getting abstain counts
+		// Check if all three are not getting miss counts
 		for i := 0; i < 3; i++ {
 			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
 			require.NoError(t, err)
-			require.EqualValues(t, uint64(1), counter.AbstainCount)
+			require.EqualValues(t, uint64(0), counter.AbstainCount)
+			require.EqualValues(t, uint64(0), counter.MissCount)
 		}
 	})
 
-	t.Run("All validators miss one out of four denom votes - Miss count should increase for all", func(t *testing.T) {
+	t.Run("All validators miss one out of four denom votes - no one gets penalized", func(t *testing.T) {
 		// Reset blockchain state
 		input, msgServer := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 
-		// Set four vote targets: atom, eth, kii and usdc
+		// Set four vote targets
 		err := oracleKeeper.VoteTarget.Clear(ctx, nil)
 		require.NoError(t, err)
 		err = oracleKeeper.VoteTarget.Set(ctx, utils.AtomDenom, types.Denom{Name: utils.AtomDenom})
@@ -466,7 +466,7 @@ func TestEndblocker(t *testing.T) {
 
 		ctx = input.Ctx.WithBlockHeight(1)
 
-		// All validators vote for atom, eth and kii — skipping usdc entirely
+		// All validators vote for atom, eth and kii but not usdc
 		partialRate := randomAExchangeRate.String() + utils.AtomDenom +
 			"," + randomAExchangeRate.String() + utils.EthDenom +
 			"," + randomAExchangeRate.String() + utils.KiiDenom
@@ -490,17 +490,16 @@ func TestEndblocker(t *testing.T) {
 		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.UsdcDenom)
 		require.Error(t, err)
 
-		// All validators should have a miss count of 1 since none of them
-		// achieved a WinCount equal to the total number of vote targets (4)
+		// No one should have miss or abstain count since no one had votes for the missing denom
 		for i := 0; i < 3; i++ {
 			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
 			require.NoError(t, err)
-			require.EqualValues(t, uint64(1), counter.MissCount)
+			require.EqualValues(t, uint64(0), counter.MissCount)
 			require.EqualValues(t, uint64(0), counter.AbstainCount)
 		}
 	})
 
-	t.Run("One denom below threshold - validators who voted for it still miss", func(t *testing.T) {
+	t.Run("One denom below threshold - validators who voted for should not be penalized", func(t *testing.T) {
 		// Reset blockchain state
 		input, msgServer := SetUp(t)
 		ctx := input.Ctx
@@ -521,7 +520,7 @@ func TestEndblocker(t *testing.T) {
 		ctx = input.Ctx.WithBlockHeight(1)
 
 		// All 3 validators vote for atom, eth and kii (above threshold)
-		// Only validator 0 votes for usdc — keeping it below the ballot threshold
+		// Only validator 0 votes for usdc, keeping it below the ballot threshold
 		fullRate := randomAExchangeRate.String() + utils.AtomDenom +
 			"," + randomAExchangeRate.String() + utils.EthDenom +
 			"," + randomAExchangeRate.String() + utils.KiiDenom +
@@ -545,18 +544,18 @@ func TestEndblocker(t *testing.T) {
 		err = EndBlocker(ctx, oracleKeeper)
 		require.NoError(t, err)
 
-		// Atom, eth and kii should be stored — they passed the ballot threshold
+		// Atom, eth and kii should be stored, they passed the ballot threshold
 		for _, denom := range []string{utils.AtomDenom, utils.EthDenom, utils.KiiDenom} {
 			exchangeRateResponse, err := oracleKeeper.ExchangeRate.Get(ctx, denom)
 			require.NoError(t, err)
 			require.Equal(t, randomAExchangeRate, exchangeRateResponse.ExchangeRate)
 		}
 
-		// Usdc should not be stored — it failed the ballot threshold
+		// Usdc should not be stored, it failed the ballot threshold
 		_, err = oracleKeeper.ExchangeRate.Get(ctx, utils.UsdcDenom)
 		require.Error(t, err)
 
-		// Validators 1 and 2 voted for 3 out of 3 valid targets — their WinCount (3)
+		// Validators 1 and 2 voted for 3 out of 3 valid targets, their WinCount (3)
 		// will match len(voteTargets) (3), so they get a success
 		for i := 1; i < 3; i++ {
 			counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[i])
@@ -567,10 +566,10 @@ func TestEndblocker(t *testing.T) {
 
 		// Validator 0 voted for all 4 denoms. Usdc went to belowThresholdVoteMap
 		// and still runs through Tally, so validator 0 gets WinCount=4 and
-		// does not matches len(voteTargets) — earning a miss
+		// should also get a success
 		counter, err := oracleKeeper.VotePenaltyCounter.Get(ctx, keeper.ValAddrs[0])
 		require.NoError(t, err)
-		require.EqualValues(t, uint64(1), counter.MissCount)
+		require.EqualValues(t, uint64(0), counter.MissCount)
 		require.EqualValues(t, uint64(0), counter.AbstainCount)
 	})
 

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -76,11 +76,13 @@ func (k Keeper) SlashAndResetCounters(ctx sdk.Context) error {
 					return true, err
 				}
 
-				// Jail validator
-				err = k.StakingKeeper.Jail(ctx, consAddr)
-				if err != nil {
-					k.Logger(ctx).Error("failed to jail validator", "operator", operator.String(), "error", err)
-					return true, err
+				// Jail validator if slashing is active
+				if slashFraction.IsPositive() {
+					err = k.StakingKeeper.Jail(ctx, consAddr)
+					if err != nil {
+						k.Logger(ctx).Error("failed to jail validator", "operator", operator.String(), "error", err)
+						return true, err
+					}
 				}
 			}
 		}

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -75,6 +75,13 @@ func (k Keeper) SlashAndResetCounters(ctx sdk.Context) error {
 					k.Logger(ctx).Error("failed to slash validator", "operator", operator.String(), "error", err)
 					return true, err
 				}
+
+				// Jail validator
+				err = k.StakingKeeper.Jail(ctx, consAddr)
+				if err != nil {
+					k.Logger(ctx).Error("failed to jail validator", "operator", operator.String(), "error", err)
+					return true, err
+				}
 			}
 		}
 

--- a/x/oracle/test_helpers.go
+++ b/x/oracle/test_helpers.go
@@ -18,6 +18,7 @@ import (
 var (
 	stakingAmount       = sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
 	randomAExchangeRate = math.LegacyNewDec(1700)
+	aboveExchangeRate   = math.LegacyNewDec(100000000)
 )
 
 // SetUp returns the message server

--- a/x/oracle/types/expected_keepers.go
+++ b/x/oracle/types/expected_keepers.go
@@ -18,9 +18,10 @@ type StakingKeeper interface {
 	Validator(ctx context.Context, address sdk.ValAddress) (stakingtypes.ValidatorI, error)                                           // Retrieves a validator's information
 	TotalBondedTokens(ctx context.Context) (math.Int, error)                                                                          // Retrieves total staked tokens (useful for slashing calculations)
 	Slash(ctx context.Context, consAddr sdk.ConsAddress, infractionHeight, power int64, slashFactor math.LegacyDec) (math.Int, error) // Slashes a validator or delegate who fails to vote in the oracle
-	ValidatorsPowerStoreIterator(ctx context.Context) (corestore.Iterator, error)                                                     // Used to computing validator rankings or total power
-	MaxValidators(ctx context.Context) (uint32, error)                                                                                // Return the maximum amount of bonded validators
-	PowerReduction(ctx context.Context) (res math.Int)                                                                                // Returns the power reduction factor,
+	Jail(ctx context.Context, consAddr sdk.ConsAddress) error
+	ValidatorsPowerStoreIterator(ctx context.Context) (corestore.Iterator, error) // Used to computing validator rankings or total power
+	MaxValidators(ctx context.Context) (uint32, error)                            // Return the maximum amount of bonded validators
+	PowerReduction(ctx context.Context) (res math.Int)                            // Returns the power reduction factor,
 }
 
 // AccountKeeper is expected keeper for auth module, because I need to handle

--- a/x/oracle/types/expected_keepers.go
+++ b/x/oracle/types/expected_keepers.go
@@ -18,10 +18,10 @@ type StakingKeeper interface {
 	Validator(ctx context.Context, address sdk.ValAddress) (stakingtypes.ValidatorI, error)                                           // Retrieves a validator's information
 	TotalBondedTokens(ctx context.Context) (math.Int, error)                                                                          // Retrieves total staked tokens (useful for slashing calculations)
 	Slash(ctx context.Context, consAddr sdk.ConsAddress, infractionHeight, power int64, slashFactor math.LegacyDec) (math.Int, error) // Slashes a validator or delegate who fails to vote in the oracle
-	Jail(ctx context.Context, consAddr sdk.ConsAddress) error
-	ValidatorsPowerStoreIterator(ctx context.Context) (corestore.Iterator, error) // Used to computing validator rankings or total power
-	MaxValidators(ctx context.Context) (uint32, error)                            // Return the maximum amount of bonded validators
-	PowerReduction(ctx context.Context) (res math.Int)                            // Returns the power reduction factor,
+	Jail(ctx context.Context, consAddr sdk.ConsAddress) error                                                                         // Jail validators
+	ValidatorsPowerStoreIterator(ctx context.Context) (corestore.Iterator, error)                                                     // Used to computing validator rankings or total power
+	MaxValidators(ctx context.Context) (uint32, error)                                                                                // Return the maximum amount of bonded validators
+	PowerReduction(ctx context.Context) (res math.Int)                                                                                // Returns the power reduction factor,
 }
 
 // AccountKeeper is expected keeper for auth module, because I need to handle


### PR DESCRIPTION
# Description
Re-enable jailing on oracle module after fixing the following behaviors
- Denoms with no votes are no longer trigger a miss on everyone
- Overperformers (voting correctly on belowThreshold denoms) no longer get punished
- Validators need to have every above threshold denom correctly to get a success

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With added tests and pipelines

# PR Checklist:

Make sure each step was done:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
