### PR TITLE
fix(oracle): add denom length validation and query result limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+
+- Add denom string length validation (max 128 bytes) to oracle precompile and query server to prevent memory exhaustion via oversized inputs
+- Add result limits to oracle list queries (ExchangeRates, Actives, VoteTargets capped at 1000; PriceSnapshotHistory capped at 500) to prevent unbounded iteration
+
 ## v7.1.0-mainnet - 2026-03-13
 
 ### Fixed

--- a/precompiles/oracle/types.go
+++ b/precompiles/oracle/types.go
@@ -11,7 +11,8 @@ import (
 
 // MaxDenomLength is the maximum allowed length for denom strings
 // This prevents DoS attacks via extremely long strings
-const MaxDenomLength = 256
+// Aligned with SDK's maximum denom length (x/tokenfactory/types/denoms.go)
+const MaxDenomLength = 128
 
 // ParseGetExchangeRateArgs parses the arguments for the GetExchangeRate method
 func ParseGetExchangeRateArgs(args []interface{}) (*oracletypes.QueryExchangeRateRequest, error) {

--- a/precompiles/oracle/types.go
+++ b/precompiles/oracle/types.go
@@ -9,6 +9,10 @@ import (
 	oracletypes "github.com/kiichain/kiichain/v7/x/oracle/types"
 )
 
+// MaxDenomLength is the maximum allowed length for denom strings
+// This prevents DoS attacks via extremely long strings
+const MaxDenomLength = 256
+
 // ParseGetExchangeRateArgs parses the arguments for the GetExchangeRate method
 func ParseGetExchangeRateArgs(args []interface{}) (*oracletypes.QueryExchangeRateRequest, error) {
 	// Check the number of arguments, should be 1
@@ -20,6 +24,11 @@ func ParseGetExchangeRateArgs(args []interface{}) (*oracletypes.QueryExchangeRat
 	denom, ok := args[0].(string)
 	if !ok || denom == "" {
 		return nil, fmt.Errorf("invalid denom")
+	}
+
+	// Validate denom length to prevent DoS via oversized strings
+	if len(denom) > MaxDenomLength {
+		return nil, fmt.Errorf("denom too long: max %d bytes, got %d", MaxDenomLength, len(denom))
 	}
 
 	// Create the QueryExchangeRateRequest and return

--- a/precompiles/oracle/types_test.go
+++ b/precompiles/oracle/types_test.go
@@ -2,6 +2,7 @@ package oracle
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,6 +68,64 @@ func TestParseTwapsArgsValidation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := ParseGetTwapsArgs(tc.args)
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestParseGetExchangeRateArgsDenomLength(t *testing.T) {
+	testCases := []struct {
+		name        string
+		args        []interface{}
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "valid - normal denom",
+			args:        []interface{}{"uatom"},
+			expectError: false,
+		},
+		{
+			name:        "valid - denom at max length",
+			args:        []interface{}{strings.Repeat("a", MaxDenomLength)},
+			expectError: false,
+		},
+		{
+			name:        "invalid - denom exceeds max length",
+			args:        []interface{}{strings.Repeat("a", MaxDenomLength+1)},
+			expectError: true,
+			errContains: "denom too long",
+		},
+		{
+			name:        "invalid - extremely long denom",
+			args:        []interface{}{strings.Repeat("x", 10000)},
+			expectError: true,
+			errContains: "denom too long",
+		},
+		{
+			name:        "invalid - empty denom",
+			args:        []interface{}{""},
+			expectError: true,
+			errContains: "invalid denom",
+		},
+		{
+			name:        "invalid - wrong number of args",
+			args:        []interface{}{},
+			expectError: true,
+			errContains: "invalid number of arguments",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ParseGetExchangeRateArgs(tc.args)
 			if tc.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errContains)

--- a/x/oracle/keeper/query_server.go
+++ b/x/oracle/keeper/query_server.go
@@ -64,14 +64,21 @@ func (qs QueryServer) ExchangeRate(ctx context.Context, req *types.QueryExchange
 	return response, nil
 }
 
+// MaxQueryResults is the maximum number of results returned by list queries
+// This prevents memory exhaustion from unbounded iteration
+const MaxQueryResults = 1000
+
 // ExchangeRates returns all exchange rates
 func (qs QueryServer) ExchangeRates(ctx context.Context, req *types.QueryExchangeRatesRequest) (*types.QueryExchangeRatesResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	exchangeRates := []types.DenomOracleExchangeRate{}
+	count := 0
 	err := qs.Keeper.ExchangeRate.Walk(sdkCtx, nil, func(denom string, exchangeRate types.OracleExchangeRate) (bool, error) {
 		exchangeRates = append(exchangeRates, types.DenomOracleExchangeRate{Denom: denom, OracleExchangeRate: &exchangeRate})
-		return false, nil
+		count++
+		// Limit results to prevent memory exhaustion
+		return count >= MaxQueryResults, nil
 	})
 	if err != nil {
 		return nil, err
@@ -85,9 +92,12 @@ func (qs QueryServer) Actives(ctx context.Context, req *types.QueryActivesReques
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	denomsActive := []string{}
+	count := 0
 	err := qs.Keeper.ExchangeRate.Walk(sdkCtx, nil, func(denom string, exchangeRate types.OracleExchangeRate) (bool, error) {
 		denomsActive = append(denomsActive, denom)
-		return false, nil
+		count++
+		// Limit results to prevent memory exhaustion
+		return count >= MaxQueryResults, nil
 	})
 	if err != nil {
 		return nil, err
@@ -106,15 +116,21 @@ func (qs QueryServer) VoteTargets(ctx context.Context, req *types.QueryVoteTarge
 	return &types.QueryVoteTargetsResponse{VoteTargets: voteTargets}, err
 }
 
+// MaxSnapshotResults is the maximum number of snapshots returned
+const MaxSnapshotResults = 500
+
 // PriceSnapshotHistory queries all snapshots
 func (qs QueryServer) PriceSnapshotHistory(ctx context.Context, req *types.QueryPriceSnapshotHistoryRequest) (*types.QueryPriceSnapshotHistoryResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// Get the snapshots available on the KVStore
 	priceSnapshots := []types.PriceSnapshot{}
+	count := 0
 	err := qs.Keeper.PriceSnapshot.Walk(sdkCtx, nil, func(_ int64, snapshot types.PriceSnapshot) (bool, error) {
 		priceSnapshots = append(priceSnapshots, snapshot)
-		return false, nil
+		count++
+		// Limit results to prevent memory exhaustion
+		return count >= MaxSnapshotResults, nil
 	})
 	if err != nil {
 		return nil, err

--- a/x/oracle/keeper/query_server.go
+++ b/x/oracle/keeper/query_server.go
@@ -38,6 +38,10 @@ func (qs QueryServer) Params(ctx context.Context, req *types.QueryParamsRequest)
 	return &types.QueryParamsResponse{Params: &params}, nil
 }
 
+// MaxDenomLength is the maximum allowed length for denom strings
+// This prevents DoS attacks via extremely long strings in queries
+const MaxDenomLength = 256
+
 // ExchangeRate returns the exchange rate specific by denom
 func (qs QueryServer) ExchangeRate(ctx context.Context, req *types.QueryExchangeRateRequest) (*types.QueryExchangeRateResponse, error) {
 	// Validate 544
@@ -47,6 +51,10 @@ func (qs QueryServer) ExchangeRate(ctx context.Context, req *types.QueryExchange
 
 	if len(req.Denom) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "empty denom")
+	}
+
+	if len(req.Denom) > MaxDenomLength {
+		return nil, status.Error(codes.InvalidArgument, "denom length exceeds maximum allowed length")
 	}
 
 	// Get exchange rate by denom

--- a/x/oracle/keeper/query_server.go
+++ b/x/oracle/keeper/query_server.go
@@ -40,7 +40,8 @@ func (qs QueryServer) Params(ctx context.Context, req *types.QueryParamsRequest)
 
 // MaxDenomLength is the maximum allowed length for denom strings
 // This prevents DoS attacks via extremely long strings in queries
-const MaxDenomLength = 256
+// Aligned with SDK's maximum denom length (x/tokenfactory/types/denoms.go)
+const MaxDenomLength = 128
 
 // ExchangeRate returns the exchange rate specific by denom
 func (qs QueryServer) ExchangeRate(ctx context.Context, req *types.QueryExchangeRateRequest) (*types.QueryExchangeRateResponse, error) {
@@ -117,11 +118,20 @@ func (qs QueryServer) Actives(ctx context.Context, req *types.QueryActivesReques
 // VoteTargets queries the voting target list on current vote period
 func (qs QueryServer) VoteTargets(ctx context.Context, req *types.QueryVoteTargetsRequest) (*types.QueryVoteTargetsResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	// Get the vote targets
-	voteTargets, err := qs.Keeper.GetVoteTargets(sdkCtx)
 
-	// Return the response and the error
-	return &types.QueryVoteTargetsResponse{VoteTargets: voteTargets}, err
+	voteTargets := []string{}
+	count := 0
+	err := qs.Keeper.VoteTarget.Walk(sdkCtx, nil, func(denom string, denomInfo types.Denom) (bool, error) {
+		voteTargets = append(voteTargets, denom)
+		count++
+		// Limit results to prevent memory exhaustion
+		return count >= MaxQueryResults, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.QueryVoteTargetsResponse{VoteTargets: voteTargets}, nil
 }
 
 // MaxSnapshotResults is the maximum number of snapshots returned

--- a/x/oracle/keeper/query_server_test.go
+++ b/x/oracle/keeper/query_server_test.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -287,4 +288,68 @@ func TestQuerySlashWindow(t *testing.T) {
 	// validation
 	require.NoError(t, err)
 	require.Equal(t, expectedWindowProgress, res.WindowProgress)
+}
+
+func TestQueryExchangeRateDenomLength(t *testing.T) {
+	input := CreateTestInput(t)
+	oracleKeeper := input.OracleKeeper
+	ctx := input.Ctx
+
+	querier := NewQueryServer(oracleKeeper)
+
+	testCases := []struct {
+		name        string
+		denom       string
+		expectError bool
+		errContains string
+	}{
+		{
+			name:        "valid - normal denom",
+			denom:       utils.AtomDenom,
+			expectError: false,
+		},
+		{
+			name:        "valid - denom at max length",
+			denom:       strings.Repeat("a", MaxDenomLength),
+			expectError: false,
+		},
+		{
+			name:        "rejected - denom exceeds max length by one",
+			denom:       strings.Repeat("a", MaxDenomLength+1),
+			expectError: true,
+			errContains: "denom length exceeds maximum",
+		},
+		{
+			name:        "rejected - extremely long denom",
+			denom:       strings.Repeat("x", 10000),
+			expectError: true,
+			errContains: "denom length exceeds maximum",
+		},
+		{
+			name:        "rejected - empty denom",
+			denom:       "",
+			expectError: true,
+			errContains: "empty denom",
+		},
+	}
+
+	// Set a rate so valid-length queries can succeed
+	rate := math.LegacyNewDec(12)
+	err := oracleKeeper.SetBaseExchangeRateWithDefault(ctx, utils.AtomDenom, rate)
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := querier.ExchangeRate(ctx, &types.QueryExchangeRateRequest{Denom: tc.denom})
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+				require.Nil(t, res)
+			} else if tc.denom == utils.AtomDenom {
+				// Only the seeded denom will return a result
+				require.NoError(t, err)
+				require.NotNil(t, res)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

This PR addresses security vulnerabilities discovered during a security audit of the KiiChain oracle module.

## Vulnerabilities Fixed

### 1. HIGH: Missing Denom String Length Validation
**Files:** \precompiles/oracle/types.go\, \x/oracle/keeper/query_server.go\

No maximum length validation for denom strings in oracle queries. Extremely long strings could cause memory exhaustion during KVStore operations.

**Fix:** Added \MaxDenomLength\ constant (128 bytes, matching the SDK constraint) with validation in both the precompile parser and the gRPC query handler, ensuring all callers are protected.

### 2. HIGH: Unbounded Memory Allocation in Oracle Queries (DoS)
**File:** \x/oracle/keeper/query_server.go\

Multiple query functions (\ExchangeRates\, \Actives\, \VoteTargets\, \PriceSnapshotHistory\) iterated over all stored data without any limits, allowing attackers to exhaust validator memory.

**Fix:** Added \MaxQueryResults\ (1000) and \MaxSnapshotResults\ (500) constants to limit iteration and prevent memory exhaustion across all list-style queries.

## Impact Assessment

| Severity | Issue | Impact |
|----------|-------|--------|
| HIGH | Missing denom validation | Memory exhaustion via oversized inputs |
| HIGH | Unbounded query iteration | Memory exhaustion, validator DoS |

## Breaking Changes

None. All changes are backward compatible and only affect input validation and resource limits.