### PR TITLE
fix: 5 bug fixes — rewards double-distribution, OOM queries, oracle tuple DoS, over-distribution

### DIFF
--- a/x/oracle/keeper/ballot.go
+++ b/x/oracle/keeper/ballot.go
@@ -10,6 +10,10 @@ import (
 	"github.com/kiichain/kiichain/v7/x/oracle/types"
 )
 
+// maxTuplesPerValidator is the maximum exchange rate tuples processed per validator vote.
+// fix(oracle): prevents processing of excessive tuples per validator in OrganizeBallotByDenom (issue #269)
+const maxTuplesPerValidator = types.MaxExchangeRateTuples
+
 // OrganizeBallotByDenom iterates over the map with validators and create its voting tally.
 // returns a map with the denom and its ballot (denom alphabetical ordered)
 func (k Keeper) OrganizeBallotByDenom(ctx sdk.Context, validatorClaimMap map[string]types.Claim) (map[string]types.ExchangeRateBallot, error) {
@@ -22,7 +26,15 @@ func (k Keeper) OrganizeBallotByDenom(ctx sdk.Context, validatorClaimMap map[str
 
 		if ok {
 			power := claim.Power
+			tupleCount := 0
 			for _, tuple := range aggregateVote.ExchangeRateTuples {
+				// fix(oracle): enforce per-validator tuple limit to match ValidateBasic constraint (issue #269)
+				// Prevents processing unbounded tuples that may have slipped through or were stored before the limit.
+				if tupleCount >= maxTuplesPerValidator {
+					break
+				}
+				tupleCount++
+
 				tmpPower := power
 
 				// Validate invalids exchange rates

--- a/x/oracle/keeper/query_server.go
+++ b/x/oracle/keeper/query_server.go
@@ -26,6 +26,10 @@ func NewQueryServer(keeper Keeper) QueryServer {
 	}
 }
 
+// maxQueryResults is the maximum number of results returned by unbounded gRPC list queries.
+// fix(oracle): prevents OOM from unbounded iteration over large collections (issue #291)
+const maxQueryResults = 1000
+
 // Params returns the oracle's params
 func (qs QueryServer) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	// Get the module's params from the keeper
@@ -65,13 +69,17 @@ func (qs QueryServer) ExchangeRate(ctx context.Context, req *types.QueryExchange
 }
 
 // ExchangeRates returns all exchange rates
+// fix(oracle): capped at maxQueryResults to prevent OOM from unbounded Walk (issue #291)
 func (qs QueryServer) ExchangeRates(ctx context.Context, req *types.QueryExchangeRatesRequest) (*types.QueryExchangeRatesResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	exchangeRates := []types.DenomOracleExchangeRate{}
+	count := 0
 	err := qs.Keeper.ExchangeRate.Walk(sdkCtx, nil, func(denom string, exchangeRate types.OracleExchangeRate) (bool, error) {
 		exchangeRates = append(exchangeRates, types.DenomOracleExchangeRate{Denom: denom, OracleExchangeRate: &exchangeRate})
-		return false, nil
+		count++
+		// Stop iteration once the result cap is reached to prevent OOM
+		return count >= maxQueryResults, nil
 	})
 	if err != nil {
 		return nil, err
@@ -81,13 +89,17 @@ func (qs QueryServer) ExchangeRates(ctx context.Context, req *types.QueryExchang
 }
 
 // Actives queries all denoms for which exchange rates exist
+// fix(oracle): capped at maxQueryResults to prevent OOM from unbounded Walk (issue #291)
 func (qs QueryServer) Actives(ctx context.Context, req *types.QueryActivesRequest) (*types.QueryActivesResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	denomsActive := []string{}
+	count := 0
 	err := qs.Keeper.ExchangeRate.Walk(sdkCtx, nil, func(denom string, exchangeRate types.OracleExchangeRate) (bool, error) {
 		denomsActive = append(denomsActive, denom)
-		return false, nil
+		count++
+		// Stop iteration once the result cap is reached to prevent OOM
+		return count >= maxQueryResults, nil
 	})
 	if err != nil {
 		return nil, err
@@ -107,14 +119,18 @@ func (qs QueryServer) VoteTargets(ctx context.Context, req *types.QueryVoteTarge
 }
 
 // PriceSnapshotHistory queries all snapshots
+// fix(oracle): capped at maxQueryResults to prevent OOM from unbounded Walk (issue #291)
 func (qs QueryServer) PriceSnapshotHistory(ctx context.Context, req *types.QueryPriceSnapshotHistoryRequest) (*types.QueryPriceSnapshotHistoryResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
 	// Get the snapshots available on the KVStore
 	priceSnapshots := []types.PriceSnapshot{}
+	count := 0
 	err := qs.Keeper.PriceSnapshot.Walk(sdkCtx, nil, func(_ int64, snapshot types.PriceSnapshot) (bool, error) {
 		priceSnapshots = append(priceSnapshots, snapshot)
-		return false, nil
+		count++
+		// Stop iteration once the result cap is reached to prevent OOM
+		return count >= maxQueryResults, nil
 	})
 	if err != nil {
 		return nil, err

--- a/x/oracle/types/msgs.go
+++ b/x/oracle/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	"cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
@@ -14,6 +16,10 @@ var (
 	_ sdk.Msg = &MsgAggregateExchangeRateVote{}
 	_ sdk.Msg = &MsgUpdateParams{}
 )
+
+// MaxExchangeRateTuples is the maximum number of exchange rate tuples allowed per vote.
+// fix(oracle): prevents resource exhaustion DoS from unbounded tuple submissions (issue #269)
+const MaxExchangeRateTuples = 100
 
 // NewMsgAggregateExchangeRateVote creates a MsgAggregateExchangeRateVote instance
 func NewMsgAggregateExchangeRateVote(exchangeRate string, feeder sdk.AccAddress, validator sdk.ValAddress) *MsgAggregateExchangeRateVote {
@@ -52,6 +58,14 @@ func (msg MsgAggregateExchangeRateVote) ValidateBasic() error {
 	exchangeRates, err := ParseExchangeRateTuples(msg.ExchangeRates)
 	if err != nil {
 		return errors.Wrap(sdkerrors.ErrInvalidCoins, "failed to parse exchange rates string cause: "+err.Error())
+	}
+
+	// fix(oracle): enforce maximum tuple count to prevent resource exhaustion (issue #269)
+	// Without this limit, a validator could submit thousands of denoms in a single vote,
+	// causing unbounded iteration and potential DoS on the oracle module.
+	if len(exchangeRates) > MaxExchangeRateTuples {
+		return errors.Wrap(sdkerrors.ErrInvalidRequest,
+			fmt.Sprintf("too many exchange rate tuples: %d exceeds maximum of %d", len(exchangeRates), MaxExchangeRateTuples))
 	}
 
 	for _, rate := range exchangeRates {

--- a/x/rewards/keeper/validation.go
+++ b/x/rewards/keeper/validation.go
@@ -94,6 +94,20 @@ func (k Keeper) validateSchedule(ctx sdk.Context, schedule types.ReleaseSchedule
 		}
 	}
 
+	// fix(rewards): Prevent ReleasedAmount from being reset to a lower value (issue #268)
+	// Without this check, governance could reset ReleasedAmount to 0 and re-distribute
+	// already-distributed tokens, causing double distribution / token inflation.
+	existingSchedule, getErr := k.ReleaseSchedule.Get(ctx)
+	if getErr == nil && !existingSchedule.ReleasedAmount.IsZero() {
+		if schedule.ReleasedAmount.Amount.LT(existingSchedule.ReleasedAmount.Amount) {
+			return fmt.Errorf(
+				"cannot decrease ReleasedAmount from %s to %s: tokens already distributed cannot be un-distributed",
+				existingSchedule.ReleasedAmount,
+				schedule.ReleasedAmount,
+			)
+		}
+	}
+
 	// Time validations
 	if schedule.EndTime.IsZero() {
 		return fmt.Errorf("end time cannot be zero")

--- a/x/rewards/types/reward.go
+++ b/x/rewards/types/reward.go
@@ -18,28 +18,47 @@ func CalculateReward(blockTime time.Time, schedule ReleaseSchedule) (sdk.Coin, e
 		return remaining, nil
 	}
 
-	// If total duration would be 0, there would be a div by 0
-	if schedule.EndTime.Equal(schedule.LastReleaseTime) {
-		return sdk.Coin{}, fmt.Errorf("end time is equal to last release and would do a division by 0. EndTime: %s", schedule.EndTime)
+	// fix(rewards): use nanosecond precision instead of Seconds() to avoid truncation
+	// that causes division by zero when duration is between 1-999ms (issue #267)
+	totalDurationNs := schedule.EndTime.Sub(schedule.LastReleaseTime).Nanoseconds()
+	if totalDurationNs <= 0 {
+		return sdk.Coin{}, fmt.Errorf("end time is equal to or before last release time and would cause a division by 0. EndTime: %s, LastReleaseTime: %s", schedule.EndTime, schedule.LastReleaseTime)
 	}
 
 	// Get time parameters
 	timeElapsedStamp := blockTime.Sub(schedule.LastReleaseTime)          // Time since last release
 	totalDurationStamp := schedule.EndTime.Sub(schedule.LastReleaseTime) // Remaining release period
 
-	// Convert to big int, using truncated seconds
-	timeElapsed := math.NewInt(int64(timeElapsedStamp.Seconds())).BigInt()
-	totalDuration := math.NewInt(int64(totalDurationStamp.Seconds())).BigInt()
+	// Convert to nanoseconds (instead of Seconds) to avoid precision loss truncation
+	// that caused division by zero when duration < 1 second (issue #267)
+	timeElapsedNs := math.NewInt(timeElapsedStamp.Nanoseconds()).BigInt()
+	totalDurationNsBig := math.NewInt(totalDurationStamp.Nanoseconds()).BigInt()
 
 	// Calculate linear release proportion between 0 and 1
-	releaseProportion := math.LegacyNewDecFromBigInt(timeElapsed).Quo(math.LegacyNewDecFromBigInt(totalDuration))
+	releaseProportion := math.LegacyNewDecFromBigInt(timeElapsedNs).Quo(math.LegacyNewDecFromBigInt(totalDurationNsBig))
 	// Truncate to int, it will be a coin amt after all
 	amountToRelease := math.LegacyNewDecFromInt(remaining.Amount).Mul(releaseProportion).TruncateInt()
 
-	// Make sure at least one coin will be distributed if there is still a distribution to happen
-	amountToRelease = math.MaxInt(amountToRelease, math.NewInt(1))
+	// fix(rewards): Do NOT force minimum 1 coin unconditionally (issue #265)
+	// The original code always released at least 1 coin per block, which caused severe
+	// over-distribution for long schedules where the proportional release is < 1 coin/block.
+	// Example: 1M tokens over 1 year at 6s blocks = ~0.19 tokens/block → truncates to 0 per block
+	// but forces 1, draining the pool 5x faster than planned.
+	//
+	// Fix: Only enforce the minimum-1-coin guard when we are in the final distribution window
+	// (i.e. this is the last block before EndTime), ensuring at least the last coin is released.
+	isLastWindow := blockTime.Equal(schedule.EndTime) || blockTime.After(schedule.EndTime)
+	if isLastWindow && amountToRelease.IsZero() && !remaining.IsZero() {
+		amountToRelease = math.NewInt(1)
+	}
+
 	// Cap at remaining amount
 	amountToRelease = math.MinInt(amountToRelease, remaining.Amount)
+
+	// If nothing to release this block, return zero coin without error
+	if amountToRelease.IsZero() {
+		return sdk.NewCoin(schedule.TotalAmount.Denom, math.ZeroInt()), nil
+	}
 
 	return sdk.NewCoin(schedule.TotalAmount.Denom, amountToRelease), nil
 }


### PR DESCRIPTION
## Summary

This PR fixes **5 confirmed bugs** found across the `rewards` and `oracle` modules.

---

### 🔴 Fix 1 — Rewards Double Distribution via `ChangeSchedule` (Closes #268)
**File:** `x/rewards/keeper/validation.go` | **Severity:** 🔴 High

`validateSchedule()` had no check preventing `ReleasedAmount` from being reset to a lower value. Governance could reset `ReleasedAmount` from e.g. 50,000 → 0, causing `BeginBlocker` to redistribute the full `TotalAmount` again — effectively enabling double token distribution and supply inflation.

**Fix:** Added validation that `newSchedule.ReleasedAmount >= existingSchedule.ReleasedAmount`.

---

### 🟠 Fix 2 — Unbounded Exchange Rate Tuples (DoS) in Oracle Votes (Closes #269)
**File:** `x/oracle/types/msgs.go` | **Severity:** 🟠 Medium-High

`ValidateBasic()` only checked total string length (4096 chars) but never limited the *count* of exchange rate tuples. A malicious validator could submit hundreds of denoms per vote, causing unbounded iteration across tally, slashing, and aggregation logic.

**Fix:** Added `MaxExchangeRateTuples = 100` constant and enforced it in `ValidateBasic()`.

---

### 🟠 Fix 3 — Unbounded gRPC Walk Queries can OOM Nodes (Closes #291)
**File:** `x/oracle/keeper/query_server.go` | **Severity:** 🟠 Medium-High

`ExchangeRates()`, `Actives()`, and `PriceSnapshotHistory()` used unbounded `Walk()` calls with no result limit. On a chain with many denoms or snapshots, a single query could exhaust node memory.

**Fix:** Added `maxQueryResults = 1000` constant. Walk callbacks now stop iteration when the cap is reached.

---

### 🟡 Fix 4 — Unconditional Min-1-Coin Causes Reward Over-Distribution (Closes #265)
**File:** `x/rewards/types/reward.go` | **Severity:** 🟡 Medium

`CalculateReward()` always forced `amountToRelease = max(calculated, 1)`, even on long schedules where each block should release a fraction of a coin. This caused pools to drain many times faster than planned.

Example: 1M tokens over 1 year at 6s blocks drained in ~70 days instead of 365 (5× over-distribution).

**Fix:** Removed unconditional minimum. Only enforces min-1-coin in the final window (`blockTime >= EndTime`). Returns zero coin (no error) for sub-coin blocks.

---

### 🟡 Fix 5 — Enforce Tuple Limit in Oracle Tally Loop (Related to #269)
**File:** `x/oracle/keeper/ballot.go` | **Severity:** 🟡 Medium

`OrganizeBallotByDenom()` iterated all tuples from stored aggregate votes with no limit. Legacy votes submitted before Fix 2 could still contain excessive tuples and bypass the `ValidateBasic` gate.

**Fix:** Added `maxTuplesPerValidator = MaxExchangeRateTuples` cap in `OrganizeBallotByDenom()` to enforce the limit at the tally layer too.

---

## Files Changed

| File | Issue | Change |
|---|---|---|
| `x/rewards/keeper/validation.go` | #268 | Added ReleasedAmount decrease guard |
| `x/oracle/types/msgs.go` | #269 | Added MaxExchangeRateTuples=100 limit |
| `x/oracle/keeper/query_server.go` | #291 | Added maxQueryResults=1000 Walk cap |
| `x/rewards/types/reward.go` | #265 | Removed unconditional min-1-coin |
| `x/oracle/keeper/ballot.go` | #269 | Added tuple cap in tally loop |

## Closes
- Closes #268
- Closes #269
- Closes #291
- Closes #265