### PR TITLE
fix: disable fee abstraction when base token price is 0 to prevent incorrect fee conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add denom string length validation (max 128 bytes) to oracle precompile and query server to prevent memory exhaustion via oversized inputs
 - Add result limits to oracle list queries (ExchangeRates, Actives, VoteTargets capped at 1000; PriceSnapshotHistory capped at 500) to prevent unbounded iteration
 - Fix NewClaim constructor assigning power to Weight field instead of the weight parameter (x/oracle/types/ballot.go)
+- Disable fee abstraction when base token price is 0 to prevent incorrect fee conversions
 
 ## v7.1.0-mainnet - 2026-03-13
 

--- a/x/feeabstraction/keeper/oracle.go
+++ b/x/feeabstraction/keeper/oracle.go
@@ -36,7 +36,7 @@ func (k Keeper) CalculateFeeTokenPrices(ctx sdk.Context) error {
 
 	// Find the price for the base token
 	baseTokenPrice, ok := twapPriceMap[params.NativeOracleDenom]
-	if !ok {
+	if !ok || !baseTokenPrice.IsPositive() {
 		// Disable fee abstraction if there is no pricing
 		k.Logger(ctx).Debug("%s has no price, feeabstraction disabled", params.NativeOracleDenom)
 		params.Enabled = false

--- a/x/feeabstraction/keeper/oracle_test.go
+++ b/x/feeabstraction/keeper/oracle_test.go
@@ -42,6 +42,21 @@ func (s *KeeperTestSuite) TestCalculateFeeTokenPrices() {
 			},
 		},
 		{
+			name: "module disabled when base token price is zero",
+			malleate: func(ctx sdk.Context) sdk.Context {
+				// Create TWAPs with zero price for the base token (kii)
+				startTime := ctx.BlockTime()
+				ctx = s.createTwaps(ctx, startTime, math.LegacyZeroDec(), 100, "kii")
+				return ctx
+			},
+			postCheck: func(ctx sdk.Context) {
+				// Module must be disabled when baseTokenPrice is zero
+				params, err := s.app.FeeAbstractionKeeper.Params.Get(ctx)
+				s.Require().NoError(err)
+				s.Require().False(params.Enabled)
+			},
+		},
+		{
 			name: "calculate fee token prices",
 			malleate: func(ctx sdk.Context) sdk.Context {
 				// Mock oracle twaps


### PR DESCRIPTION
# Description

Disable fee abstraction when base token price is 0 to prevent incorrect fee conversions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Regression test

# PR Checklist:

Make sure each step was done:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
