### PR TITLE
fix(app): replace panic with error returns in InitChainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Replace `panic()` calls with proper error returns in `InitChainer` to prevent node crashes on initialization failures ([#264](https://github.com/KiiChain/kiichain/issues/264))
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))
 - Add denom string length validation (max 128 bytes) to oracle precompile and query server to prevent memory exhaustion via oversized inputs
 - Add result limits to oracle list queries (ExchangeRates, Actives, VoteTargets capped at 1000; PriceSnapshotHistory capped at 500) to prevent unbounded iteration

--- a/app/app.go
+++ b/app/app.go
@@ -378,16 +378,16 @@ func (app *KiichainApp) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 func (app *KiichainApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
 	var genesisState GenesisState
 	if err := tmjson.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to unmarshal genesis state: %w", err)
 	}
 
 	if err := app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap()); err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to set module version map: %w", err)
 	}
 
 	response, err := app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to init genesis: %w", err)
 	}
 
 	return response, nil

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	abci "github.com/cometbft/cometbft/abci/types"
+
 	db "github.com/cosmos/cosmos-db"
 
 	"cosmossdk.io/log"
@@ -48,4 +50,28 @@ func TestKiichainApp_Export(t *testing.T) {
 	app := kiihelpers.Setup(t)
 	_, err := app.ExportAppStateAndValidators(true, []string{}, []string{})
 	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
+}
+
+func TestInitChainerReturnsErrorOnInvalidJSON(t *testing.T) {
+	app := kiichain.NewKiichainApp(
+		log.NewNopLogger(),
+		db.NewMemDB(),
+		nil,
+		true,
+		map[int64]bool{},
+		kiichain.DefaultNodeHome,
+		EmptyAppOptions{},
+		emptyWasmOption,
+	)
+
+	ctx := app.NewContext(true)
+
+	var initErr error
+	require.NotPanics(t, func() {
+		_, initErr = app.InitChainer(ctx, &abci.RequestInitChain{
+			AppStateBytes: []byte("invalid json"),
+		})
+	})
+	require.Error(t, initErr, "InitChainer should return an error for invalid JSON")
+	require.Contains(t, initErr.Error(), "failed to unmarshal genesis state")
 }


### PR DESCRIPTION
﻿## Summary

Replaces three panic() calls in InitChainer with proper error returns using mt.Errorf wrapping, preventing node crashes on initialization failures.

## Changes

### Modified: pp/app.go
- 	mjson.Unmarshal failure: panic(err) replaced with eturn nil, fmt.Errorf("failed to unmarshal genesis state: %w", err)
- SetModuleVersionMap failure: panic(err) replaced with eturn nil, fmt.Errorf("failed to set module version map: %w", err)
- InitGenesis failure: panic(err) replaced with eturn nil, fmt.Errorf("failed to init genesis: %w", err)

### Modified: CHANGELOG.md
- Added entry under ## Unreleased

## Rationale

The function signature already returns (*abci.ResponseInitChain, error) but was using panic instead of the error return, violating its own contract. CometBFT ABCI layer handles returned errors gracefully, so there is no need to crash the process.

Closes #264
