### PR TITLE
ci: add Go vulnerability scanning with govulncheck and gosec

### DIFF
--- a/.github/workflows/go-vuln-scan.yml
+++ b/.github/workflows/go-vuln-scan.yml
@@ -1,0 +1,55 @@
+name: Go Vulnerability Scan
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+  pull_request:
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+  schedule:
+    # Run weekly on Monday at 08:00 UTC to catch newly disclosed vulnerabilities
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          check-latest: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  gosec:
+    name: gosec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          check-latest: true
+
+      - name: Run gosec
+        uses: securego/gosec@master
+        with:
+          args: -severity high -confidence medium -exclude-generated ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add Go vulnerability scanning CI workflow using `govulncheck` and `gosec` ([#65](https://github.com/KiiChain/kiichain/issues/65))
+
 ### Fixed
 
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))


### PR DESCRIPTION
﻿## Summary

Adds a Go vulnerability scanning CI workflow that integrates govulncheck and gosec into the pipeline, as requested in #65.

## Changes

### New: .github/workflows/go-vuln-scan.yml

Two parallel jobs:

**govulncheck** (official Go vulnerability database)
- Checks all Go dependencies against the Go vulnerability database
- Fails the build if any known vulnerability affects the project

**gosec** (static security analysis)
- Scans Go source for high-severity security anti-patterns
- Filters to high severity + medium confidence to reduce noise
- Excludes generated code

### Triggers
- On PRs that touch .go, go.mod, or go.sum files
- On pushes to main with the same path filter
- Weekly scheduled run (Monday 08:00 UTC) to catch newly disclosed CVEs

### Modified: CHANGELOG.md
- Added entry under ## Unreleased / ### Added

## Design Decisions

- **Path filtering**: only triggers on Go-related file changes to avoid unnecessary runs
- **Weekly schedule**: catches vulnerabilities disclosed after the last code change
- **gosec severity filter**: -severity high -confidence medium avoids noisy low-confidence findings while catching real issues
- **Excludes generated code**: -exclude-generated skips protobuf/mock files

Closes #65
