### PR TITLE
docs(precompiles): add oracle README and top-level overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add README documentation for oracle precompile and top-level precompiles overview ([#62](https://github.com/KiiChain/kiichain/issues/62))
+
 ### Fixed
 
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))

--- a/precompiles/README.md
+++ b/precompiles/README.md
@@ -1,0 +1,36 @@
+# KiiChain Precompiles
+
+KiiChain ships with EVM precompiled contracts that expose Cosmos SDK module functionality to Solidity smart contracts. These precompiles are deployed at fixed addresses and can be called like any other contract.
+
+## Available Precompiles
+
+| Precompile | Address | Description |
+|------------|---------|-------------|
+| [Oracle](./oracle/) | `0x0000000000000000000000000000000000001003` | Query exchange rates, TWAP prices from the oracle module |
+| [Staking](./staking/) | `0x0000000000000000000000000000000000000800` | Delegate, undelegate, and query delegation amounts |
+
+## Architecture
+
+Each precompile follows the same pattern:
+
+1. **Solidity Interface** (`I<Name>.sol`) — defines the EVM-callable functions
+2. **ABI** (`abi.json`) — the compiled ABI used to decode calls at runtime
+3. **Go Implementation** (`<name>.go`) — implements `vm.PrecompiledContract`, routing method IDs to handler functions
+4. **Query/Tx Handlers** (`query.go` / `tx.go`) — execute the underlying Cosmos SDK keeper calls
+5. **Type Parsers** (`types.go`) — parse and validate ABI-decoded arguments
+
+## Utilities
+
+- **`common/`** — shared Solidity types (`Types.sol`) used across precompiles
+- **`scripts/`** — tooling to convert Solidity compiler output to Hardhat-compatible artifacts
+
+## Security
+
+- All precompile inputs are validated (e.g., denom length capped at 128 bytes)
+- Query results are bounded to prevent unbounded memory allocation
+- Gas metering follows the `KVGasConfig` / `TransientGasConfig` from the Cosmos SDK store
+
+## Further Reading
+
+- [KiiChain Documentation](https://docs.kiiglobal.io/)
+- [Cosmos EVM Precompiles](https://github.com/cosmos/evm/tree/main/precompiles)

--- a/precompiles/oracle/README.md
+++ b/precompiles/oracle/README.md
@@ -1,0 +1,118 @@
+# Oracle Precompile
+
+The oracle precompile enables EVM smart contracts to query KiiChain's oracle module for real-time exchange rates and TWAP (Time-Weighted Average Price) data.
+
+## Overview
+
+- **Address**: `0x0000000000000000000000000000000000001003`
+- **Interface**: [`IOracle.sol`](./IOracle.sol)
+- **Module**: `x/oracle`
+
+## Functions
+
+### `getExchangeRate(string denom)`
+
+Returns the current exchange rate for a single denomination.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `denom` | `string` | The denomination to query (max 128 bytes) |
+
+**Returns:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `rate` | `string` | The current exchange rate |
+| `lastUpdate` | `string` | Block height of the last update |
+| `lastUpdateTimestamp` | `int64` | Unix timestamp of the last update |
+
+### `getExchangeRates()`
+
+Returns exchange rates for all active denominations.
+
+**Returns:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `denoms` | `string[]` | Array of denomination names |
+| `rates` | `string[]` | Array of exchange rates |
+| `lastUpdate` | `string[]` | Array of last update block heights |
+| `lastUpdateTimestamps` | `uint256[]` | Array of last update timestamps |
+
+> **Note:** Results are capped at 1000 entries to prevent unbounded memory allocation.
+
+### `getTwaps(uint256 lookbackSeconds)`
+
+Returns TWAP values for all denominations over the specified lookback window.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lookbackSeconds` | `uint256` | Number of seconds to look back for the TWAP calculation |
+
+**Returns:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `denoms` | `string[]` | Array of denomination names |
+| `twaps` | `string[]` | Array of TWAP values |
+
+## Usage
+
+```solidity
+pragma solidity ^0.8.17;
+
+import "./IOracle.sol";
+
+contract MyDeFiApp {
+    IOracle constant ORACLE = IOracle(0x0000000000000000000000000000000000001003);
+
+    /// @notice Get the current price of a token
+    function getPrice(string memory denom) external view returns (string memory) {
+        (string memory rate, , ) = ORACLE.getExchangeRate(denom);
+        return rate;
+    }
+
+    /// @notice Get all available prices
+    function getAllPrices()
+        external
+        view
+        returns (string[] memory denoms, string[] memory rates)
+    {
+        (denoms, rates, , ) = ORACLE.getExchangeRates();
+    }
+
+    /// @notice Get TWAP over the last hour
+    function getHourlyTwap()
+        external
+        view
+        returns (string[] memory denoms, string[] memory twaps)
+    {
+        (denoms, twaps) = ORACLE.getTwaps(3600);
+    }
+}
+```
+
+## Security Considerations
+
+- **Denom length validation**: Denom strings are capped at 128 bytes (`MaxDenomLength`). Requests with longer denoms are rejected.
+- **Result limits**: List queries (`getExchangeRates`) return at most 1000 results (`MaxQueryResults`).
+- **Gas metering**: All calls are gas-metered via the standard `KVGasConfig`. Malformed inputs (< 4 bytes) return 0 required gas.
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `IOracle.sol` | Solidity interface definition |
+| `abi.json` | Compiled ABI for runtime decoding |
+| `oracle.go` | Precompile entry point, method routing |
+| `query.go` | Query handler implementations |
+| `types.go` | Argument parsing and validation |
+| `types_test.go` | Unit tests for argument parsing |
+| `query_test.go` | Unit tests for query handlers |
+| `integration_test.go` | Integration tests |
+
+## Further Reading
+
+- [KiiChain Documentation](https://docs.kiiglobal.io/)
+- [Oracle Module (`x/oracle`)](../../x/oracle/)
+- [Precompiles Overview](../README.md)


### PR DESCRIPTION
﻿## Summary

Adds README documentation for the oracle precompile and a top-level precompiles overview, as requested in #62. The staking precompile already has a README (added via PR #107).

## Changes

### New: `precompiles/README.md`
- Overview table of all precompiles with addresses and descriptions
- Architecture pattern explanation (interface, ABI, Go implementation, handlers, type parsers)
- Utilities section documenting `common/` and `scripts/`
- Security notes and external links

### New: `precompiles/oracle/README.md`
- Full API reference for all three query methods:
  - `getExchangeRate(string denom)` — single denomination rate
  - `getExchangeRates()` — all active rates (capped at 1000 results)
  - `getTwaps(uint256 lookbackSeconds)` — TWAP over a lookback window
- Parameter tables and return value documentation
- Solidity usage example with a complete contract
- Security considerations (denom length validation, result limits, gas metering)
- File structure reference

### Modified: `CHANGELOG.md`
- Added entry under `## Unreleased` / `### Added`

## Note

This addresses the oracle precompile portion of #62. The staking precompile was already documented in PR #107. If other precompiles are added in the future, they can follow the same README pattern.

Partial fix for #62
