### PR TITLE
fix: ensure feetokens cannot be initialized as new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Disable fee abstraction when base token price is 0 to prevent incorrect fee conversions
 - Ensure native oracle denoms are always on whitelist and registered as vote targets when updating fee abstraction params
 - Validate rewards baseDenom using sdk.ValidateDenom to enforce proper denom format (min 3 chars, valid characters, no leading digits)
+- Ensure feeTokens is not nil at genesis
 
 ## v7.1.0-mainnet - 2026-03-13
 

--- a/x/feeabstraction/keeper/genesis.go
+++ b/x/feeabstraction/keeper/genesis.go
@@ -18,8 +18,12 @@ func (k Keeper) InitGenesis(ctx sdk.Context, gs types.GenesisState) error {
 		return err
 	}
 
-	// Set the fee tokens
-	return k.FeeTokens.Set(ctx, *gs.FeeTokens)
+	// Set the fee tokens (treat nil as an empty collection)
+	feeTokens := types.FeeTokenMetadataCollection{}
+	if gs.FeeTokens != nil {
+		feeTokens = *gs.FeeTokens
+	}
+	return k.FeeTokens.Set(ctx, feeTokens)
 }
 
 // ExportGenesis reads the module collections and return the genesis state

--- a/x/feeabstraction/types/genesis.go
+++ b/x/feeabstraction/types/genesis.go
@@ -27,6 +27,11 @@ func (gs *GenesisState) Validate() error {
 		return err
 	}
 
+	// FeeTokens must be at least empty
+	if gs.FeeTokens == nil {
+		return errorsmod.Wrap(ErrInvalidFeeTokenMetadata, "fee_tokens must not be nil; supply an empty collection")
+	}
+
 	// Validate each fee token metadata and check for duplicate denoms
 	denomSet := make(map[string]struct{})
 	for _, token := range gs.FeeTokens.Items {

--- a/x/feeabstraction/types/genesis_test.go
+++ b/x/feeabstraction/types/genesis_test.go
@@ -32,6 +32,11 @@ func TestGenesisStateValidate(t *testing.T) {
 			),
 		},
 		{
+			name:         "invalid - nil fee tokens",
+			genesisState: types.NewGenesisState(types.DefaultParams(), nil),
+			errContains:  "fee_tokens must not be nil",
+		},
+		{
 			name: "invalid - bad param",
 			genesisState: types.NewGenesisState(
 				types.NewParams("", "coinoracle", types.DefaultClampFactor, 0, true),


### PR DESCRIPTION
# Description

Ensure that feetokens on genesis cannot be nil

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Regression test

# PR Checklist:

Make sure each step was done:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
