### PR TITLE
fix(app): return InitChainer errors instead of panics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -378,16 +378,16 @@ func (app *KiichainApp) EndBlocker(ctx sdk.Context) (sdk.EndBlock, error) {
 func (app *KiichainApp) InitChainer(ctx sdk.Context, req *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
 	var genesisState GenesisState
 	if err := tmjson.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to unmarshal genesis state: %w", err)
 	}
 
 	if err := app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap()); err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to set module version map: %w", err)
 	}
 
 	response, err := app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to initialize genesis: %w", err)
 	}
 
 	return response, nil

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	abci "github.com/cometbft/cometbft/abci/types"
 	db "github.com/cosmos/cosmos-db"
 
 	"cosmossdk.io/log"
@@ -48,4 +49,19 @@ func TestKiichainApp_Export(t *testing.T) {
 	app := kiihelpers.Setup(t)
 	_, err := app.ExportAppStateAndValidators(true, []string{}, []string{})
 	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
+}
+
+func TestKiichainApp_InitChainerReturnsErrorForInvalidGenesisJSON(t *testing.T) {
+	app := kiihelpers.Setup(t)
+
+	req := &abci.RequestInitChain{
+		AppStateBytes: []byte("{ invalid json }"),
+	}
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = app.InitChainer(app.NewContext(false), req)
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to unmarshal genesis state")
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -58,10 +58,14 @@ func TestKiichainApp_InitChainerReturnsErrorForInvalidGenesisJSON(t *testing.T) 
 		AppStateBytes: []byte("{ invalid json }"),
 	}
 
-	var err error
+	var (
+		resp *abci.ResponseInitChain
+		err  error
+	)
 	require.NotPanics(t, func() {
-		_, err = app.InitChainer(app.NewContext(false), req)
+		resp, err = app.InitChainer(app.NewContext(false), req)
 	})
+	require.Nil(t, resp)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to unmarshal genesis state")
 }


### PR DESCRIPTION
## Summary
- replace panic calls in InitChainer with explicit wrapped errors
- preserve function contract by returning an error from InitChainer on failures
- add a regression test that invalid genesis JSON returns an error without panicking

## Testing
- go test -tags=test ./app -run TestKiichainApp_InitChainerReturnsErrorForInvalidGenesisJSON -count=1 -v -timeout 10m
- go test -tags=test ./app -run TestKiichainApp_ -count=1 -timeout 10m

Closes #264
