### PR TITLE
ci: add Swagger freshness check on proto changes

### DIFF
--- a/.github/workflows/swagger-check.yml
+++ b/.github/workflows/swagger-check.yml
@@ -1,0 +1,47 @@
+name: Swagger Check
+
+on:
+  pull_request:
+    paths:
+      - "proto/**"
+      - "client/docs/**"
+      - "x/**/query.go"
+      - "x/**/tx.go"
+      - ".github/workflows/swagger-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "proto/**"
+      - "client/docs/**"
+
+permissions:
+  contents: read
+
+jobs:
+  swagger-diff:
+    name: Check Swagger is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Regenerate Swagger
+        run: make proto-swagger-gen
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --quiet --exit-code client/docs/swagger-ui/swagger.yaml client/docs/swagger-ui/swagger.json; then
+            echo "::error::Swagger files are out of date. Please run 'make proto-swagger-gen' and commit the changes."
+            echo ""
+            echo "Changed files:"
+            git diff --stat client/docs/swagger-ui/swagger.yaml client/docs/swagger-ui/swagger.json
+            echo ""
+            echo "Diff:"
+            git diff client/docs/swagger-ui/swagger.yaml client/docs/swagger-ui/swagger.json
+            exit 1
+          fi
+          echo "Swagger files are up to date."

--- a/.github/workflows/swagger-check.yml
+++ b/.github/workflows/swagger-check.yml
@@ -33,9 +33,10 @@ jobs:
         run: |
           # Override protoImage so the Docker container runs as the runner user,
           # avoiding "permission denied" on the mounted workspace volume.
+          # Set HOME to /tmp so buf can write its cache (default /.cache is root-only).
           PROTO_VER=$(grep '^protoVer=' Makefile | cut -d= -f2)
           make proto-swagger-gen \
-            "protoImage=docker run --rm --user $(id -u):$(id -g) -v $(pwd):/workspace --workdir /workspace ghcr.io/cosmos/proto-builder:${PROTO_VER}"
+            "protoImage=docker run --rm --user $(id -u):$(id -g) -e HOME=/tmp -v $(pwd):/workspace --workdir /workspace ghcr.io/cosmos/proto-builder:${PROTO_VER}"
 
       - name: Check for uncommitted changes
         run: |

--- a/.github/workflows/swagger-check.yml
+++ b/.github/workflows/swagger-check.yml
@@ -30,7 +30,12 @@ jobs:
           go-version: "1.24"
 
       - name: Regenerate Swagger
-        run: make proto-swagger-gen
+        run: |
+          # Override protoImage so the Docker container runs as the runner user,
+          # avoiding "permission denied" on the mounted workspace volume.
+          PROTO_VER=$(grep '^protoVer=' Makefile | cut -d= -f2)
+          make proto-swagger-gen \
+            "protoImage=docker run --rm --user $(id -u):$(id -g) -v $(pwd):/workspace --workdir /workspace ghcr.io/cosmos/proto-builder:${PROTO_VER}"
 
       - name: Check for uncommitted changes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add CI workflow to verify Swagger files are up to date after `make proto-swagger-gen`; fails PR if generated files differ from committed ones ([#66](https://github.com/KiiChain/kiichain/issues/66))
+
 ### Fixed
 
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))


### PR DESCRIPTION
## Summary

Add a CI workflow that automatically verifies Swagger files are up to date after proto changes, as requested in #66.

## Problem

Proto file changes require running `make proto-swagger-gen` to regenerate `client/docs/swagger-ui/swagger.yaml` and `swagger.json`. This step is easy to forget, leading to stale API docs.

## Solution

### `.github/workflows/swagger-check.yml`

- **Triggers**: PRs touching `proto/`, `client/docs/`, or `x/**/query.go`/`x/**/tx.go` files; pushes to `main`
- **What it does**: Runs `make proto-swagger-gen` (which uses the `ghcr.io/cosmos/proto-builder:0.13.0` Docker image) and then checks for a diff on the generated swagger files
- **On failure**: Prints the exact diff showing what changed, with a clear error message telling the contributor to run `make proto-swagger-gen` and commit the result

## How it helps

- PRs that modify proto definitions or query/tx handlers will fail CI if the swagger files aren't regenerated
- Clear error output shows exactly what's out of date
- No false positives — only runs when relevant files change

Closes #66
