### PR TITLE
ci: add Docker image publishing workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add Docker image publishing CI workflow that builds and pushes multi-platform images to GHCR on tagged releases (#61)
+
 ### Fixed
 
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))


### PR DESCRIPTION
﻿## Summary

Adds a GitHub Actions workflow that automatically builds and publishes multi-platform Docker images to GitHub Container Registry (GHCR) whenever a version tag (`v*`) is pushed.

Closes #61

## What this does

- **Trigger**: Fires on any `v*` tag push (e.g. `v7.2.0`)
- **Registry**: Pushes to `ghcr.io/kiichain/kiichain`
- **Platforms**: `linux/amd64` and `linux/arm64` (matches the wasmvm libs already in the Dockerfile)
- **Tags**: Semver (`7.2.0`), minor (`7.2`), and git SHA
- **Caching**: GitHub Actions cache (BuildKit `type=gha`) for faster rebuilds
- **Auth**: Uses the built-in `GITHUB_TOKEN` — no extra secrets required

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/docker-publish.yml` | New workflow |
| `CHANGELOG.md` | Unreleased entry |
