### PR TITLE
ci: add Buf Schema Registry publishing workflow

### DIFF
--- a/.github/workflows/buf-publish.yml
+++ b/.github/workflows/buf-publish.yml
@@ -1,0 +1,31 @@
+name: Buf Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  buf-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint protos
+        working-directory: proto
+        run: buf lint
+
+      - name: Push to Buf Schema Registry
+        working-directory: proto
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: buf push --tag "${{ github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add Buf Schema Registry publishing CI that pushes protobuf profiles to buf.build on tagged releases (#63)
+
 ### Fixed
 
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))


### PR DESCRIPTION
﻿## Summary

Adds a GitHub Actions workflow that automatically lints and publishes protobuf definitions to the [Buf Schema Registry](https://buf.build/kiichain/kiichain) whenever a version tag (`v*`) is pushed.

Closes #63

## What this does

- **Trigger**: Fires on any `v*` tag push (e.g. `v7.2.0`)
- **Lint**: Runs `buf lint` against `proto/` before publishing
- **Publish**: Pushes to `buf.build/kiichain/kiichain` using the existing `proto/buf.yaml` module config
- **Tagging**: Tags the BSR commit with the Git tag name (e.g. `v7.2.0`)
- **Auth**: Requires a `BUF_TOKEN` repository secret (generated from [buf.build settings](https://buf.build/settings/user))

## Setup required

A maintainer needs to:
1. Create an API token at https://buf.build/settings/user
2. Add it as a repository secret named `BUF_TOKEN`

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/buf-publish.yml` | New workflow |
| `CHANGELOG.md` | Unreleased entry |
