### PR TITLE
fix: crosscheck UpdateTokenMetadata decimals with ERC20 contracts and bank metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Ensure that `UpdateTokenMetadata.Decimals` matches the ERC20 or bank records
 - Fixed odd validation on tokenfactory change admin that blocked removing admin from the token
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))
 - Add denom string length validation (max 128 bytes) to oracle precompile and query server to prevent memory exhaustion via oversized inputs

--- a/x/feeabstraction/keeper/msg_server.go
+++ b/x/feeabstraction/keeper/msg_server.go
@@ -2,6 +2,9 @@ package keeper
 
 import (
 	"context"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"cosmossdk.io/errors"
 	"cosmossdk.io/math"
@@ -9,6 +12,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	erc20types "github.com/cosmos/evm/x/erc20/types"
 
 	"github.com/kiichain/kiichain/v7/x/feeabstraction/types"
 )
@@ -96,7 +101,8 @@ func (ms MsgServer) UpdateFeeTokens(ctx context.Context, msg *types.MsgUpdateFee
 	}
 
 	// Check if all the oracle denoms are registered on the oracle module
-	voteTargets, err := ms.oracleKeeper.GetVoteTargets(sdk.UnwrapSDKContext(ctx))
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	voteTargets, err := ms.oracleKeeper.GetVoteTargets(sdkCtx)
 	if err != nil {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("failed to get oracle vote targets: %s", err)
 	}
@@ -107,6 +113,13 @@ func (ms MsgServer) UpdateFeeTokens(ctx context.Context, msg *types.MsgUpdateFee
 	for _, feeToken := range msg.Tokens.Items {
 		if _, ok := voteTargetMap[feeToken.OracleDenom]; !ok {
 			return nil, sdkerrors.ErrInvalidRequest.Wrapf("fee token denom %s is not registered on the oracle module", feeToken.OracleDenom)
+		}
+	}
+
+	// Validate that the registered Decimals match the canonical decimals for each token
+	for _, feeToken := range msg.Tokens.Items {
+		if err := ms.validateFeeTokenDecimals(sdkCtx, feeToken); err != nil {
+			return nil, sdkerrors.ErrInvalidRequest.Wrapf("fee token %s decimals mismatch: %s", feeToken.Denom, err)
 		}
 	}
 
@@ -126,6 +139,58 @@ func (ms MsgServer) UpdateFeeTokens(ctx context.Context, msg *types.MsgUpdateFee
 
 	// Return the response
 	return &types.MsgUpdateFeeTokensResponse{}, nil
+}
+
+// validateFeeTokenDecimals checks that the Decimals field on a proposed fee token
+// matches the ERC20 or bank record
+func (ms MsgServer) validateFeeTokenDecimals(ctx sdk.Context, token types.UpdateTokenMetadata) error {
+	// ERC20 path
+	if strings.HasPrefix(token.Denom, erc20types.Erc20NativeCoinDenomPrefix) {
+		hexAddr := strings.TrimPrefix(token.Denom, erc20types.Erc20NativeCoinDenomPrefix)
+
+		// Look up the token pair to confirm it is registered.
+		pairID := ms.erc20Keeper.GetTokenPairID(ctx, token.Denom)
+		if len(pairID) == 0 {
+			return sdkerrors.ErrUnknownAddress.Wrapf("no ERC20 pair registered for %s", token.Denom)
+		}
+
+		// Query decimals() from the contract.
+		erc20Data, err := ms.erc20Keeper.QueryERC20(ctx, common.HexToAddress(hexAddr))
+		if err != nil {
+			return errors.Wrapf(err, "failed to query ERC20 decimals for %s", token.Denom)
+		}
+
+		if uint32(erc20Data.Decimals) != token.Decimals {
+			return sdkerrors.ErrInvalidRequest.Wrapf(
+				"declared decimals %d does not match contract decimals %d",
+				token.Decimals, erc20Data.Decimals,
+			)
+		}
+		return nil
+	}
+
+	// Bank-native path
+	meta, found := ms.bankKeeper.GetDenomMetaData(ctx, token.Denom)
+	if !found {
+		// No metadata registered; skip the check.
+		return nil
+	}
+
+	// Takes maximum exponent across all DenomUnits.
+	var maxExp uint32
+	for _, unit := range meta.DenomUnits {
+		if unit.Exponent > maxExp {
+			maxExp = unit.Exponent
+		}
+	}
+
+	if maxExp != token.Decimals {
+		return sdkerrors.ErrInvalidRequest.Wrapf(
+			"declared decimals %d does not match bank metadata decimals %d",
+			token.Decimals, maxExp,
+		)
+	}
+	return nil
 }
 
 // validateAuthority checks if address authority is valid and same as expected

--- a/x/feeabstraction/keeper/msg_server.go
+++ b/x/feeabstraction/keeper/msg_server.go
@@ -148,7 +148,7 @@ func (ms MsgServer) validateFeeTokenDecimals(ctx sdk.Context, token types.Update
 	if strings.HasPrefix(token.Denom, erc20types.Erc20NativeCoinDenomPrefix) {
 		hexAddr := strings.TrimPrefix(token.Denom, erc20types.Erc20NativeCoinDenomPrefix)
 
-		// Look up the token pair to confirm it is registered.
+		// Look up the token pair to confirm it is registered
 		pairID := ms.erc20Keeper.GetTokenPairID(ctx, token.Denom)
 		if len(pairID) == 0 {
 			return sdkerrors.ErrUnknownAddress.Wrapf("no ERC20 pair registered for %s", token.Denom)
@@ -172,11 +172,12 @@ func (ms MsgServer) validateFeeTokenDecimals(ctx sdk.Context, token types.Update
 	// Bank-native path
 	meta, found := ms.bankKeeper.GetDenomMetaData(ctx, token.Denom)
 	if !found {
-		// No metadata registered; skip the check.
+		// IBC denoms and tokens without on-chain metadata cannot be validated;
+		// allow them through. If metadata is present, decimals MUST match
 		return nil
 	}
 
-	// Takes maximum exponent across all DenomUnits.
+	// Takes maximum exponent across all DenomUnits
 	var maxExp uint32
 	for _, unit := range meta.DenomUnits {
 		if unit.Exponent > maxExp {

--- a/x/feeabstraction/keeper/msg_server_test.go
+++ b/x/feeabstraction/keeper/msg_server_test.go
@@ -3,8 +3,12 @@ package keeper_test
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
+	erc20types "github.com/cosmos/evm/x/erc20/types"
+
+	"github.com/kiichain/kiichain/v7/app/apptesting"
 	"github.com/kiichain/kiichain/v7/x/feeabstraction/types"
 	oracletypes "github.com/kiichain/kiichain/v7/x/oracle/types"
 )
@@ -228,6 +232,142 @@ func (s *KeeperTestSuite) TestUpdateFeeTokens() {
 					s.Require().Equal(tc.msg.Tokens.Items[i].Decimals, token.Decimals)
 					s.Require().True(token.Price.IsZero(), "expected price to be 0 for denom %s, got %s", token.Denom, token.Price)
 				}
+			}
+		})
+	}
+}
+
+// TestUpdateFeeTokensDecimalsMismatch tests that MsgUpdateFeeTokens rejects
+// proposals where FeeTokenMetadata.Decimals disagrees with the existing
+// token records
+func (s *KeeperTestSuite) TestUpdateFeeTokensDecimalsMismatch() {
+	// registerOracleTarget registers a denom as a vote target on the oracle module.
+	registerOracleTarget := func(ctx sdk.Context, denom string) {
+		err := s.app.OracleKeeper.VoteTarget.Set(ctx, denom, oracletypes.Denom{Name: denom})
+		s.Require().NoError(err)
+	}
+
+	govAddr := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+
+	testCases := []struct {
+		name        string
+		malleate    func(ctx sdk.Context) sdk.Context
+		token       types.UpdateTokenMetadata
+		errContains string
+	}{
+		// ERC20
+		{
+			name: "erc20 - correct decimals accepted",
+			malleate: func(ctx sdk.Context) sdk.Context {
+				// Configure ERC20 w/ 18 decimals
+				erc20Addr, err := apptesting.DeployERC20(ctx, s.app)
+				s.Require().NoError(err)
+				_, err = s.app.Erc20Keeper.RegisterERC20(ctx, &erc20types.MsgRegisterERC20{
+					Signer:         govAddr,
+					Erc20Addresses: []string{erc20Addr.Hex()},
+				})
+				s.Require().NoError(err)
+				denom := "erc20:" + erc20Addr.Hex()
+				registerOracleTarget(ctx, "oracleerc20")
+				ctx = ctx.WithValue("erc20denom", denom)
+				return ctx
+			},
+			token:       types.NewUpdateTokenMetadata("placeholder", "oracleerc20", 18),
+			errContains: "",
+		},
+		{
+			name: "erc20 - wrong decimals rejected",
+			malleate: func(ctx sdk.Context) sdk.Context {
+				// Configure ERC20 w/ 18 decimals
+				erc20Addr, err := apptesting.DeployERC20(ctx, s.app)
+				s.Require().NoError(err)
+				_, err = s.app.Erc20Keeper.RegisterERC20(ctx, &erc20types.MsgRegisterERC20{
+					Signer:         govAddr,
+					Erc20Addresses: []string{erc20Addr.Hex()},
+				})
+				s.Require().NoError(err)
+				denom := "erc20:" + erc20Addr.Hex()
+				registerOracleTarget(ctx, "oracleerc20")
+				ctx = ctx.WithValue("erc20denom", denom)
+				return ctx
+			},
+			// DeployERC20 deploys with 18 decimals; we deliberately register 6.
+			token:       types.NewUpdateTokenMetadata("placeholder", "oracleerc20", 6),
+			errContains: "declared decimals 6 does not match contract decimals 18",
+		},
+		// Bank path
+		{
+			name: "bank - correct decimals accepted",
+			malleate: func(ctx sdk.Context) sdk.Context {
+				s.app.BankKeeper.SetDenomMetaData(ctx, banktypes.Metadata{
+					Base:    "ucoin",
+					Display: "coin",
+					DenomUnits: []*banktypes.DenomUnit{
+						{Denom: "ucoin", Exponent: 0},
+						{Denom: "coin", Exponent: 6},
+					},
+				})
+				registerOracleTarget(ctx, "oraclecoin")
+				return ctx
+			},
+			token:       types.NewUpdateTokenMetadata("ucoin", "oraclecoin", 6),
+			errContains: "",
+		},
+		{
+			name: "bank - wrong decimals rejected",
+			malleate: func(ctx sdk.Context) sdk.Context {
+				s.app.BankKeeper.SetDenomMetaData(ctx, banktypes.Metadata{
+					Base:    "ucoin",
+					Display: "coin",
+					DenomUnits: []*banktypes.DenomUnit{
+						{Denom: "ucoin", Exponent: 0},
+						{Denom: "coin", Exponent: 6},
+					},
+				})
+				registerOracleTarget(ctx, "oraclecoin")
+				return ctx
+			},
+			// Metadata says 6; we deliberately declare 18.
+			token:       types.NewUpdateTokenMetadata("ucoin", "oraclecoin", 18),
+			errContains: "declared decimals 18 does not match bank metadata decimals 6",
+		},
+		{
+			name: "bank - no metadata registered, check skipped",
+			malleate: func(ctx sdk.Context) sdk.Context {
+				registerOracleTarget(ctx, "oracleunknown")
+				return ctx
+			},
+			token:       types.NewUpdateTokenMetadata("unknowncoin", "oracleunknown", 8),
+			errContains: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			cachedCtx, _ := s.ctx.CacheContext()
+
+			if tc.malleate != nil {
+				cachedCtx = tc.malleate(cachedCtx)
+			}
+
+			// For ERC20 cases the denom depends on deployed address
+			token := tc.token
+			if denom, ok := cachedCtx.Value("erc20denom").(string); ok && denom != "" {
+				token.Denom = denom
+			}
+
+			msg := types.NewMessageUpdateFeeTokens(
+				govAddr,
+				*types.NewUpdateTokenMetadataCollection(token),
+			)
+
+			_, err := s.msgServer.UpdateFeeTokens(cachedCtx, msg)
+
+			if tc.errContains != "" {
+				s.Require().Error(err)
+				s.Require().Contains(err.Error(), tc.errContains)
+			} else {
+				s.Require().NoError(err)
 			}
 		})
 	}

--- a/x/feeabstraction/types/expected_keepers.go
+++ b/x/feeabstraction/types/expected_keepers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	erc20types "github.com/cosmos/evm/x/erc20/types"
 
@@ -18,6 +19,7 @@ import (
 type Erc20Keeper interface {
 	GetTokenPairID(ctx sdk.Context, token string) []byte
 	GetTokenPair(ctx sdk.Context, id []byte) (erc20types.TokenPair, bool)
+	QueryERC20(ctx sdk.Context, contract common.Address) (erc20types.ERC20Data, error)
 	ConvertERC20(
 		goCtx context.Context,
 		msg *erc20types.MsgConvertERC20,
@@ -32,6 +34,7 @@ type Erc20Keeper interface {
 // BankKeeper defines the expected interface for the Bank keeper
 type BankKeeper interface {
 	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	GetDenomMetaData(ctx context.Context, denom string) (banktypes.Metadata, bool)
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 }
 


### PR DESCRIPTION
# Description

Crosscheck UpdateTokenMetadata decimals with ERC20 contracts and bank metadata to avoid any possible mismatch

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added simple checks for both ERC20 and bank metadata infos

# PR Checklist:

Make sure each step was done:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
