### PR TITLE
docs: add section to fee abstraction readme on feature being used automaticly

### DIFF
--- a/x/feeabstraction/README.md
+++ b/x/feeabstraction/README.md
@@ -13,6 +13,11 @@ The functionality of the module allows:
   - Applies a clamp factor to limit extreme price deviations.
   - Disables tokens with missing or zero prices.
 
+This feature is enabled for all users and cannot be opted out, fees we'll be payed with alternate tokens if:
+- The user has no native funds for the transaction
+- The user has enough of one of the alternate token
+- The token is enabled as alternate fee 
+
 ## Core functionality
 
 In its code, the module changes the fee-paying ante handlers to allow payment of fees with tokens different from the native gas token.
@@ -45,6 +50,9 @@ We have a few safety mechanisms to ensure the prices are valid:
 - If prices go to zero, the fee token is disabled
 - The Twap of the token is used to avoid sudden price changes
 - Price changes are clamped to avoid extreme values
+
+These measures are needed and in place because the price update happens at `BeginBlock`,
+meaning users only get an estimate of token prices, not actual values, when they do transactions.
 
 ### Fee payment
 

--- a/x/feeabstraction/README.md
+++ b/x/feeabstraction/README.md
@@ -13,10 +13,10 @@ The functionality of the module allows:
   - Applies a clamp factor to limit extreme price deviations.
   - Disables tokens with missing or zero prices.
 
-This feature is enabled for all users and cannot be opted out, fees we'll be payed with alternate tokens if:
+This feature is enabled for all users and cannot be opted out, fees will be payed with alternate tokens if:
 - The user has no native funds for the transaction
-- The user has enough of one of the alternate token
-- The token is enabled as alternate fee 
+- The user has enough of one of the alternate tokens
+- The token is enabled as an alternate fee token
 
 ## Core functionality
 


### PR DESCRIPTION
# Description

Improved readme with a section mentioning the auto-usage of other tokens and the price being estimated by default.

## Type of change

- [x] Documentation (updates documentation on the project)