### PR TITLE
fix: enforce wasmbind uses msg server on tokenfactory set denom metadata path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Refactor `PerformSetMetadata` in wasmbinding to delegate to `msgServer.SetDenomMetadata`, ensuring the `EnableSetMetadata` capability check is enforced
 - Ensure that `UpdateTokenMetadata.Decimals` matches the ERC20 or bank records
 - Fixed odd validation on tokenfactory change admin that blocked removing admin from the token
 - Fix division-by-zero chain halt in `CalculateReward` caused by sub-second schedule durations; replace `Seconds()` truncation with `Nanoseconds()` precision and release full remaining reward when `EndTime <= LastReleaseTime` ([#267](https://github.com/KiiChain/kiichain/issues/267))

--- a/wasmbinding/tokenfactory/message_plugin.go
+++ b/wasmbinding/tokenfactory/message_plugin.go
@@ -87,7 +87,7 @@ func PerformCreateDenom(f *tokenfactorykeeper.Keeper, b bankkeeper.Keeper, ctx s
 
 	if createDenom.Metadata != nil {
 		newDenom := resp.NewTokenDenom
-		err := PerformSetMetadata(f, b, ctx, contractAddr, newDenom, *createDenom.Metadata)
+		err := PerformSetMetadata(f, ctx, contractAddr, newDenom, *createDenom.Metadata)
 		if err != nil {
 			return nil, errorsmod.Wrap(err, "setting metadata")
 		}
@@ -249,41 +249,29 @@ func PerformForceTransfer(f *tokenfactorykeeper.Keeper, ctx sdk.Context, contrac
 
 // createDenom creates a new token denom
 func (m *CustomMessenger) SetMetadata(ctx sdk.Context, contractAddr sdk.AccAddress, setMetadata *tfbindingtypes.SetMetadata) ([]sdk.Event, [][]byte, [][]*types.Any, error) {
-	err := PerformSetMetadata(m.tokenFactory, m.bank, ctx, contractAddr, setMetadata.Denom, setMetadata.Metadata)
+	err := PerformSetMetadata(m.tokenFactory, ctx, contractAddr, setMetadata.Denom, setMetadata.Metadata)
 	if err != nil {
 		return nil, nil, utils.EmptyMsgResp, errorsmod.Wrap(err, "perform set metadata")
 	}
 	return nil, nil, utils.EmptyMsgResp, nil
 }
 
-// PerformSetMetadata is used with setMetadata to add new metadata
-// It also is called inside CreateDenom if optional metadata field is set
-func PerformSetMetadata(f *tokenfactorykeeper.Keeper, b bankkeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, denom string, metadata tfbindingtypes.Metadata) error {
-	// ensure contract address is admin of denom
-	auth, err := f.GetAuthorityMetadata(ctx, denom)
-	if err != nil {
-		return err
-	}
-	if auth.Admin != contractAddr.String() {
-		return wasmvmtypes.InvalidRequest{Err: "only admin can set metadata"}
-	}
-
+// PerformSetMetadata is used with setMetadata to add new metadata.
+// It also is called inside CreateDenom if optional metadata field is set.
+// Delegates to msgServer.SetDenomMetadata to ensure capability checks
+func PerformSetMetadata(f *tokenfactorykeeper.Keeper, ctx sdk.Context, contractAddr sdk.AccAddress, denom string, metadata tfbindingtypes.Metadata) error {
 	// ensure we are setting proper denom metadata (bank uses Base field, fill it if missing)
 	if metadata.Base == "" {
 		metadata.Base = denom
 	} else if metadata.Base != denom {
-		// this is the key that we set
 		return wasmvmtypes.InvalidRequest{Err: "Base must be the same as denom"}
 	}
 
-	// Create and validate the metadata
 	bankMetadata := WasmMetadataToSdk(metadata)
-	if err := bankMetadata.Validate(); err != nil {
-		return err
-	}
 
-	b.SetDenomMetaData(ctx, bankMetadata)
-	return nil
+	msgServer := tokenfactorykeeper.NewMsgServerImpl(*f)
+	_, err := msgServer.SetDenomMetadata(ctx, tokenfactorytypes.NewMsgSetDenomMetadata(contractAddr.String(), bankMetadata))
+	return err
 }
 
 // GetFullDenom is a function, not method, so the message_plugin can use it

--- a/wasmbinding/tokenfactory/message_plugin_test.go
+++ b/wasmbinding/tokenfactory/message_plugin_test.go
@@ -305,6 +305,125 @@ func TestMint(t *testing.T) {
 	}
 }
 
+// TestSetMetadataCapabilityGating verifies that PerformSetMetadata enforces the
+// EnableSetMetadata capability check
+func TestSetMetadataCapabilityGating(t *testing.T) {
+	creator := apptesting.RandomAccountAddress()
+
+	validMetadata := func(denom string) bindingtypes.Metadata {
+		return bindingtypes.Metadata{
+			Description: "test token",
+			DenomUnits: []bindingtypes.DenomUnit{
+				{Denom: denom, Exponent: 0},
+				{Denom: "utest", Exponent: 6},
+			},
+			Base:    denom,
+			Display: "utest",
+			Name:    "Test",
+			Symbol:  "TEST",
+		}
+	}
+
+	specs := map[string]struct {
+		capabilities []string
+		expErr       bool
+	}{
+		"succeeds when EnableSetMetadata capability is enabled": {
+			capabilities: []string{types.EnableSetMetadata},
+			expErr:       false,
+		},
+		"fails when EnableSetMetadata capability is disabled": {
+			capabilities: []string{},
+			expErr:       true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			app, ctx := helpers.SetupCustomApp(t, creator)
+
+			// Fund creator with denom creation fees
+			actorAmount := sdk.NewCoins(sdk.NewCoin(types.DefaultParams().DenomCreationFee[0].Denom, types.DefaultParams().DenomCreationFee[0].Amount.MulRaw(10)))
+			helpers.FundAccount(t, ctx, app, creator, actorAmount)
+
+			// Create a denom first (without metadata)
+			resp, err := wasmbinding.PerformCreateDenom(&app.TokenFactoryKeeper, app.BankKeeper, ctx, creator, &bindingtypes.CreateDenom{
+				Subdenom: "GATE",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			denom := fmt.Sprintf("factory/%s/GATE", creator.String())
+
+			// Override capability set
+			app.TokenFactoryKeeper.SetEnabledCapabilities(ctx, spec.capabilities)
+
+			gotErr := wasmbinding.PerformSetMetadata(&app.TokenFactoryKeeper, ctx, creator, denom, validMetadata(denom))
+			if spec.expErr {
+				require.Error(t, gotErr)
+				require.ErrorContains(t, gotErr, "capability is not enabled on chain")
+			} else {
+				require.NoError(t, gotErr)
+			}
+		})
+	}
+}
+
+// TestCreateDenomWithMetadataCapabilityGating verifies that the optional metadata
+// path in PerformCreateDenom respects the EnableSetMetadata capability check
+func TestCreateDenomWithMetadataCapabilityGating(t *testing.T) {
+	creator := apptesting.RandomAccountAddress()
+
+	specs := map[string]struct {
+		capabilities []string
+		expErr       bool
+	}{
+		"succeeds when EnableSetMetadata capability is enabled": {
+			capabilities: []string{types.EnableSetMetadata},
+			expErr:       false,
+		},
+		"fails when EnableSetMetadata capability is disabled": {
+			capabilities: []string{},
+			expErr:       true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			app, ctx := helpers.SetupCustomApp(t, creator)
+
+			// Fund creator with denom creation fees
+			actorAmount := sdk.NewCoins(sdk.NewCoin(types.DefaultParams().DenomCreationFee[0].Denom, types.DefaultParams().DenomCreationFee[0].Amount.MulRaw(10)))
+			helpers.FundAccount(t, ctx, app, creator, actorAmount)
+
+			// Override capability set before CreateDenom so the metadata step sees it
+			app.TokenFactoryKeeper.SetEnabledCapabilities(ctx, spec.capabilities)
+
+			subdenom := "META"
+			denom := fmt.Sprintf("factory/%s/%s", creator.String(), subdenom)
+			metadata := bindingtypes.Metadata{
+				Description: "test token",
+				DenomUnits: []bindingtypes.DenomUnit{
+					{Denom: denom, Exponent: 0},
+					{Denom: "umeta", Exponent: 6},
+				},
+				Base:    denom,
+				Display: "umeta",
+				Name:    "Meta",
+				Symbol:  "META",
+			}
+
+			_, gotErr := wasmbinding.PerformCreateDenom(&app.TokenFactoryKeeper, app.BankKeeper, ctx, creator, &bindingtypes.CreateDenom{
+				Subdenom: subdenom,
+				Metadata: &metadata,
+			})
+			if spec.expErr {
+				require.Error(t, gotErr)
+				require.ErrorContains(t, gotErr, "capability is not enabled on chain")
+			} else {
+				require.NoError(t, gotErr)
+			}
+		})
+	}
+}
+
 // TestBurn tests the burning of tokens
 func TestBurn(t *testing.T) {
 	creator := apptesting.RandomAccountAddress()


### PR DESCRIPTION
# Description

Enforce wasmbind uses msg server on tokenfactory set denom metadata path

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added regression test

# PR Checklist:

Make sure each step was done:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
