### PR TITLE
feat: add governance and related events to custom modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Emit `update_params`, `fund_pool`, `change_schedule`, and `reward_distributed` events from x/rewards
+- Emit `update_params` and `set_denom_metadata` events from tokenfactory
+- Emit `update_params`, `update_fee_tokens`, `module_disabled` and `token_disabled` events on fee abstraction
+- Emit `update_params` event on oracle module
+
 ### Fixed
 
 - Ensure that `UpdateTokenMetadata.Decimals` matches the ERC20 or bank records

--- a/wasmbinding/tokenfactory/message_plugin.go
+++ b/wasmbinding/tokenfactory/message_plugin.go
@@ -283,6 +283,12 @@ func PerformSetMetadata(f *tokenfactorykeeper.Keeper, b bankkeeper.Keeper, ctx s
 	}
 
 	b.SetDenomMetaData(ctx, bankMetadata)
+
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		tokenfactorytypes.TypeMsgSetDenomMetadata,
+		sdk.NewAttribute(tokenfactorytypes.AttributeDenom, denom),
+	))
+
 	return nil
 }
 

--- a/x/feeabstraction/keeper/msg_server.go
+++ b/x/feeabstraction/keeper/msg_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -81,6 +82,10 @@ func (ms MsgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams
 		return nil, err
 	}
 
+	sdkCtx.EventManager().EmitEvent(sdk.NewEvent(
+		types.TypeEventUpdateParams,
+	))
+
 	// Return the response
 	return &types.MsgUpdateParamsResponse{}, nil
 }
@@ -136,6 +141,11 @@ func (ms MsgServer) UpdateFeeTokens(ctx context.Context, msg *types.MsgUpdateFee
 	if err := ms.FeeTokens.Set(ctx, *resetFeeTokens); err != nil {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("failed to update fee tokens: %s", err)
 	}
+
+	sdkCtx.EventManager().EmitEvent(sdk.NewEvent(
+		types.TypeEventUpdateFeeTokens,
+		sdk.NewAttribute(types.TypeAttributeTokenCount, strconv.Itoa(len(msg.Tokens.Items))),
+	))
 
 	// Return the response
 	return &types.MsgUpdateFeeTokensResponse{}, nil

--- a/x/feeabstraction/keeper/oracle.go
+++ b/x/feeabstraction/keeper/oracle.go
@@ -40,7 +40,14 @@ func (k Keeper) CalculateFeeTokenPrices(ctx sdk.Context) error {
 		// Disable fee abstraction if there is no pricing
 		k.Logger(ctx).Debug("%s has no price, feeabstraction disabled", params.NativeOracleDenom)
 		params.Enabled = false
-		return k.Params.Set(ctx, params)
+		if err := k.Params.Set(ctx, params); err != nil {
+			return err
+		}
+		ctx.EventManager().EmitEvent(sdk.NewEvent(
+			types.TypeEventModuleDisabled,
+			sdk.NewAttribute(types.TypeAttributeOracleDenom, params.NativeOracleDenom),
+		))
+		return nil
 	}
 
 	// Iterate all the tokens
@@ -94,6 +101,10 @@ func (k Keeper) calculatePriceTokens(
 			token.Enabled = false
 			token.Price = math.LegacyZeroDec()
 			updateTokens = append(updateTokens, token)
+			ctx.EventManager().EmitEvent(sdk.NewEvent(
+				types.TypeEventTokenDisabled,
+				sdk.NewAttribute(types.TypeAttributeDenom, token.Denom),
+			))
 			continue
 		}
 

--- a/x/feeabstraction/types/msg.go
+++ b/x/feeabstraction/types/msg.go
@@ -15,6 +15,15 @@ var (
 	TypeAttributeOriginalFeeAmount = "original_fee"
 	TypeAttributeConvertedFee      = "converted_fee"
 	TypeAttributePrice             = "price"
+
+	TypeEventUpdateParams    = "update_params"
+	TypeEventUpdateFeeTokens = "update_fee_tokens"
+	TypeEventModuleDisabled  = "module_disabled"
+	TypeEventTokenDisabled   = "token_disabled"
+
+	TypeAttributeTokenCount  = "token_count"
+	TypeAttributeOracleDenom = "oracle_denom"
+	TypeAttributeDenom       = "denom"
 )
 
 // NewMessageUpdateParams creates a new MsgUpdateParams instance

--- a/x/oracle/keeper/msg_server.go
+++ b/x/oracle/keeper/msg_server.go
@@ -165,6 +165,12 @@ func (ms msgServer) UpdateParams(ctx context.Context, req *types.MsgUpdateParams
 		return nil, err
 	}
 
+	sdkCtx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeParamsUpdated,
+		),
+	})
+
 	// Return an empty response
 	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/oracle/types/events.go
+++ b/x/oracle/types/events.go
@@ -7,6 +7,7 @@ const (
 	EventTypeFeedDelegate       = "feed_delegate"
 	EventTypeAggregateVote      = "aggregate_vote"
 	EventTypeEndSlashWindow     = "end_slash_window"
+	EventTypeParamsUpdated      = "update_params"
 )
 
 // Oracle module Attribute key

--- a/x/rewards/keeper/abci.go
+++ b/x/rewards/keeper/abci.go
@@ -93,6 +93,12 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) error {
 		return err
 	}
 
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypeRewardDistributed,
+		sdk.NewAttribute(types.AttributeKeyAmount, amountToDistribute.String()),
+		sdk.NewAttribute(types.AttributeKeyTotalReleased, schedule.ReleasedAmount.String()),
+	))
+
 	k.WriteRewardMetrics(ctx, amountToDistribute, schedule.ReleasedAmount)
 
 	return nil

--- a/x/rewards/keeper/msg_server.go
+++ b/x/rewards/keeper/msg_server.go
@@ -36,6 +36,10 @@ func (k msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams)
 		return nil, err
 	}
 
+	sdk.UnwrapSDKContext(ctx).EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypeUpdateParams,
+	))
+
 	return &types.MsgUpdateParamsResponse{}, nil
 }
 
@@ -61,6 +65,12 @@ func (k msgServer) FundPool(ctx context.Context, msg *types.MsgFundPool) (*types
 	if err := k.FundCommunityPool(ctx, msg.Amount, depositor); err != nil {
 		return nil, err
 	}
+
+	sdk.UnwrapSDKContext(ctx).EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypeFundPool,
+		sdk.NewAttribute(types.AttributeKeySender, msg.Sender),
+		sdk.NewAttribute(types.AttributeKeyAmount, msg.Amount.String()),
+	))
 
 	return &types.MsgFundPoolResponse{}, nil
 }
@@ -90,6 +100,11 @@ func (k msgServer) ChangeSchedule(ctx context.Context, msg *types.MsgChangeSched
 	if err := k.ReleaseSchedule.Set(sdkCtx, schedule); err != nil {
 		return nil, fmt.Errorf("failed to set release schedule: %w", err)
 	}
+
+	sdkCtx.EventManager().EmitEvent(sdk.NewEvent(
+		types.EventTypeChangeSchedule,
+		sdk.NewAttribute(types.AttributeKeyTotalAmount, schedule.TotalAmount.String()),
+	))
 
 	return &types.MsgChangeScheduleResponse{}, nil
 }

--- a/x/rewards/types/events.go
+++ b/x/rewards/types/events.go
@@ -1,0 +1,13 @@
+package types
+
+const (
+	EventTypeUpdateParams      = "update_params"
+	EventTypeFundPool          = "fund_pool"
+	EventTypeChangeSchedule    = "change_schedule"
+	EventTypeRewardDistributed = "reward_distributed"
+
+	AttributeKeySender        = "sender"
+	AttributeKeyAmount        = "amount"
+	AttributeKeyTotalReleased = "total_released"
+	AttributeKeyTotalAmount   = "total_amount"
+)

--- a/x/tokenfactory/keeper/msg_server.go
+++ b/x/tokenfactory/keeper/msg_server.go
@@ -226,5 +226,9 @@ func (server msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdate
 		return nil, err
 	}
 
+	ctx.EventManager().EmitEvent(sdk.NewEvent(
+		types.TypeMsgUpdateParams,
+	))
+
 	return &types.MsgUpdateParamsResponse{}, nil
 }

--- a/x/tokenfactory/types/msgs.go
+++ b/x/tokenfactory/types/msgs.go
@@ -16,6 +16,7 @@ const (
 	TypeMsgForceTransfer    = "force_transfer"
 	TypeMsgChangeAdmin      = "change_admin"
 	TypeMsgSetDenomMetadata = "set_denom_metadata"
+	TypeMsgUpdateParams     = "update_params"
 )
 
 var _ sdk.Msg = &MsgCreateDenom{}


### PR DESCRIPTION
# Description

- Emit `update_params`, `fund_pool`, `change_schedule`, and `reward_distributed` events from x/rewards
- Emit `update_params` and `set_denom_metadata` events from tokenfactory
- Emit `update_params`, `update_fee_tokens`, `module_disabled` and `token_disabled` events on fee abstraction
- Emit `update_params` event on oracle module

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# PR Checklist:

Make sure each step was done:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
