### PR TITLE
fix: broken Lines of Code badge and Quick Links spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/KiiChain/kiichain)](https://github.com/KiiChain/kiichain/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/KiiChain/kiichain)](https://goreportcard.com/report/github.com/KiiChain/kiichain)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Lines of Code](https://tokei.rs/b1/github/KiiChain/kiichain)](https://github.com/KiiChain/kiichain)
+[![Lines of Code](https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/KiiChain/kiichain/badge&color=blue)](https://github.com/KiiChain/kiichain)
 [![GitHub Super-Linter](https://github.com/KiiChain/kiichain/workflows/Lint/badge.svg)](https://github.com/marketplace/actions/super-linter)
 [![GoDoc](https://godoc.org/github.com/KiiChain/kiichain?status.svg)](https://pkg.go.dev/github.com/kiichain/kiichain)
 
@@ -46,7 +46,6 @@
 <!-- markdown-link-check-disable -->
 
 - **[Join Oro Testnet](https://kiichain.io/testnet)** - Start validating on our testnet
-<!-- markdown-link-check-enable -->
 - **[Testnet Explorer](https://explorer.kiichain.io)** - View transactions and blocks
 - **[Testnet Faucet](https://explorer.kiichain.io/faucet)** - Get testnet tokens
 
@@ -286,6 +285,7 @@ Join our vibrant community and stay connected:
 - **[X (Twitter)](https://x.com/KiiChainio)** - Follow for latest updates
 <!-- markdown-link-check-enable -->
 - **[TikTok](https://www.tiktok.com/@kiichain_)** - Watch our latest content
+<!-- markdown-link-check-enable -->
 - **[LinkedIn](https://www.linkedin.com/company/kiiglobal)** - Professional updates
 
 ## License


### PR DESCRIPTION
Replace deprecated tokei.rs badge endpoint with ghloc.vercel.app via shields.io. Also remove an HTML comment between list items in the Quick Links section that was causing uneven spacing in the rendered output.