### PR TITLE
fix: tokenfactory metadata size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Ensure feeTokenMetadata initial prices after updateFeeTokenMetadata is picked up from oracle
 - Use `DecCoins.Validate()` on `RewardPool.ValidateGenesis` to catch malformed denom formats, duplicate denoms, bad ordering
 - Enforce denom consistency in `GenesisState.Validate` with `Params.TokenDenom`
+- Bound tokenfactory denom metadata size (`MaxDenomMetadataSize`) in `MsgSetDenomMetadata.ValidateBasic` and `msgServer.SetDenomMetadata` to prevent oversized metadata rewrites (including via the CosmWasm binding) from forcing unbounded native store writes that overrun the transaction's declared gas
 - Limited tokenfactory queries, removing denial of service possibility
 - Indexed admins to reduce query space on tokenfactory denom queries
 

--- a/x/tokenfactory/keeper/msg_server.go
+++ b/x/tokenfactory/keeper/msg_server.go
@@ -194,6 +194,10 @@ func (server msgServer) SetDenomMetadata(goCtx context.Context, msg *types.MsgSe
 		return nil, err
 	}
 
+	if err := types.ValidateMetadataSize(msg.Metadata); err != nil {
+		return nil, err
+	}
+
 	authorityMetadata, err := server.GetAuthorityMetadata(ctx, msg.Metadata.Base)
 	if err != nil {
 		return nil, err

--- a/x/tokenfactory/keeper/msg_server_test.go
+++ b/x/tokenfactory/keeper/msg_server_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -257,6 +258,29 @@ func (suite *KeeperTestSuite) TestSetDenomMetaDataMsg() {
 			suite.AssertEventEmitted(ctx, types.TypeMsgSetDenomMetadata, tc.expectedMessageEvents)
 		})
 	}
+}
+
+func (suite *KeeperTestSuite) TestSetDenomMetaDataOversizedRejected() {
+	suite.SetupTest()
+	suite.CreateDefaultDenom()
+
+	ctx := suite.Ctx.WithEventManager(sdk.NewEventManager())
+
+	oversized := banktypes.Metadata{
+		Description: strings.Repeat("a", types.MaxDenomMetadataSize+1),
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: suite.defaultDenom, Exponent: 0},
+			{Denom: "uosmo", Exponent: 6},
+		},
+		Base:    suite.defaultDenom,
+		Display: "uosmo",
+		Name:    "OSMO",
+		Symbol:  "OSMO",
+	}
+
+	_, err := suite.msgServer.SetDenomMetadata(ctx, types.NewMsgSetDenomMetadata(suite.TestAccs[0].String(), oversized))
+	suite.Require().ErrorIs(err, types.ErrMetadataTooLarge)
+	suite.AssertEventEmitted(ctx, types.TypeMsgSetDenomMetadata, 0)
 }
 
 // TestMintToBlockedAddr tests that minting to a blocked address (module account) fails

--- a/x/tokenfactory/types/errors.go
+++ b/x/tokenfactory/types/errors.go
@@ -20,4 +20,5 @@ var (
 	ErrCreatorTooLong           = errorsmod.Register(ModuleName, 9, fmt.Sprintf("creator too long, max length is %d bytes", MaxCreatorLength))
 	ErrDenomDoesNotExist        = errorsmod.Register(ModuleName, 10, "denom does not exist")
 	ErrCapabilityNotEnabled     = errorsmod.Register(ModuleName, 11, "this capability is not enabled on chain")
+	ErrMetadataTooLarge         = errorsmod.Register(ModuleName, 12, fmt.Sprintf("denom metadata too large, max size is %d bytes", MaxDenomMetadataSize))
 )

--- a/x/tokenfactory/types/metadata.go
+++ b/x/tokenfactory/types/metadata.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+const MaxDenomMetadataSize = 10 * 1024
+
+func ValidateMetadataSize(metadata banktypes.Metadata) error {
+	if size := metadata.Size(); size > MaxDenomMetadataSize {
+		return ErrMetadataTooLarge.Wrapf("got %d bytes, max is %d bytes", size, MaxDenomMetadataSize)
+	}
+	return nil
+}

--- a/x/tokenfactory/types/msgs.go
+++ b/x/tokenfactory/types/msgs.go
@@ -264,6 +264,11 @@ func (m MsgSetDenomMetadata) ValidateBasic() error {
 		return err
 	}
 
+	err = ValidateMetadataSize(m.Metadata)
+	if err != nil {
+		return err
+	}
+
 	_, _, err = DeconstructDenom(m.Metadata.Base)
 	if err != nil {
 		return err

--- a/x/tokenfactory/types/msgs_test.go
+++ b/x/tokenfactory/types/msgs_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	fmt "fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -439,6 +440,15 @@ func TestMsgSetDenomMetadata(t *testing.T) {
 				msg := baseMsg
 				msg.Metadata = invalidDenomMetadata
 				return msg
+			},
+			expectPass: false,
+		},
+		{
+			name: "oversized metadata",
+			msg: func() *types.MsgSetDenomMetadata {
+				oversized := denomMetadata
+				oversized.Description = strings.Repeat("a", types.MaxDenomMetadataSize+1)
+				return types.NewMsgSetDenomMetadata(addr1.String(), oversized)
 			},
 			expectPass: false,
 		},


### PR DESCRIPTION
# Description

Bounds the size of tokenfactory denom metadata to prevent oversized metadata writes from forcing unbounded native store writes.

A new `MaxDenomMetadataSize` (10 KiB) cap is enforced in two places:

- `MsgSetDenomMetadata.ValidateBasic` — rejects oversized metadata at the message-validation layer.
- `msgServer.SetDenomMetadata` — enforces the same cap inside the keeper, since the CosmWasm tokenfactory binding dispatches `SetDenomMetadata` directly and bypasses `ValidateBasic`.

A shared `ValidateMetadataSize` helper (in `x/tokenfactory/types/metadata.go`) checks the encoded metadata size against the cap and returns the new `ErrMetadataTooLarge` error.

Motivation/context: legitimate denom metadata is only a few hundred bytes. Without a cap, a large payload (via a CosmWasm contract or a direct `MsgSetDenomMetadata`) could stage an effectively unbounded native bank store write whose per-byte write gas cost can exceed the transaction's declared gas and inflate block-level gas usage. Enforcing the bound at both entry points (message and keeper) closes that path.

Dependencies: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests covering both enforcement paths and ran the tokenfactory suite locally.

- [x] `TestMsgSetDenomMetadata` (`x/tokenfactory/types/msgs_test.go`) — added an "oversized metadata" case asserting `ValidateBasic` rejects metadata over the cap.
- [x] `TestSetDenomMetaDataOversizedRejected` (`x/tokenfactory/keeper/msg_server_test.go`) — asserts the keeper/message-server path (the one used by the CosmWasm binding) rejects oversized metadata with `ErrMetadataTooLarge` and emits no event.

### Reproduce

```bash
go test ./x/tokenfactory/types/... -run TestMsgSetDenomMetadata -v
go test ./x/tokenfactory/keeper/... -run TestSetDenomMetaDataOversizedRejected -v
# or the full module suite
make test-unit
```

# PR Checklist:

- [x] Updated changelog with PR's intent
- [ ] Lint with `make lint-fix`