### PR TITLE
fix: add authz guarded router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Reject `MsgEthereumTx` from being dispatched through the authz keeper (including when nested inside `authz.MsgExec`), closing an EVM ante bypass on message-router execution paths that skip the ante handler
 - Refactor `PerformSetMetadata` in wasmbinding to delegate to `msgServer.SetDenomMetadata`, ensuring the `EnableSetMetadata` capability check is enforced
 - Ensure that `UpdateTokenMetadata.Decimals` matches the ERC20 or bank records
 - Fixed odd validation on tokenfactory change admin that blocked removing admin from the token

--- a/app/keepers/authz_router.go
+++ b/app/keepers/authz_router.go
@@ -1,0 +1,52 @@
+package keepers
+
+import (
+	errorsmod "cosmossdk.io/errors"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+)
+
+// evmMsgTypeURL is the type URL of MsgEthereumTx, cached once so it can be
+// compared cheaply when routing messages.
+var evmMsgTypeURL = sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{})
+
+// evmRejectingMessageRouter wraps a baseapp.MessageRouter and prevents EVM
+// transactions (MsgEthereumTx) from being executed through authz. EVM messages
+// carry their own signer/nonce semantics that authz grants are not designed to
+// authorize, so dispatching them via authz is blocked at the routing layer.
+type evmRejectingMessageRouter struct {
+	baseapp.MessageRouter
+}
+
+// newEVMRejectingMessageRouter wraps the given router so that any attempt to
+// route an EVM message is rejected. All non-EVM messages are delegated to the
+// underlying router unchanged.
+func newEVMRejectingMessageRouter(router baseapp.MessageRouter) baseapp.MessageRouter {
+	return evmRejectingMessageRouter{MessageRouter: router}
+}
+
+// Handler returns the message handler for msg. For MsgEthereumTx it returns a
+// handler that always fails with an unauthorized error; for every other message
+// it falls through to the wrapped router.
+func (r evmRejectingMessageRouter) Handler(msg sdk.Msg) baseapp.MsgServiceHandler {
+	if _, ok := msg.(*evmtypes.MsgEthereumTx); ok {
+		return func(sdk.Context, sdk.Msg) (*sdk.Result, error) {
+			return nil, errorsmod.Wrapf(errortypes.ErrUnauthorized, "%s is not allowed to be executed through authz", evmMsgTypeURL)
+		}
+	}
+	return r.MessageRouter.Handler(msg)
+}
+
+// HandlerByTypeURL returns the handler registered for typeURL. It returns nil
+// for the EVM message type URL so that resolution fails, and otherwise defers to
+// the wrapped router.
+func (r evmRejectingMessageRouter) HandlerByTypeURL(typeURL string) baseapp.MsgServiceHandler {
+	if typeURL == evmMsgTypeURL {
+		return nil
+	}
+	return r.MessageRouter.HandlerByTypeURL(typeURL)
+}

--- a/app/keepers/authz_router_internal_test.go
+++ b/app/keepers/authz_router_internal_test.go
@@ -1,0 +1,82 @@
+package keepers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+)
+
+// stubMessageRouter is a minimal baseapp.MessageRouter used to assert that the
+// evmRejectingMessageRouter delegates non-EVM messages to the wrapped router.
+type stubMessageRouter struct {
+	handler            baseapp.MsgServiceHandler
+	gotMsg             sdk.Msg
+	gotTypeURL         string
+	handlerCalled      bool
+	handlerByURLCalled bool
+}
+
+func (s *stubMessageRouter) Handler(msg sdk.Msg) baseapp.MsgServiceHandler {
+	s.handlerCalled = true
+	s.gotMsg = msg
+	return s.handler
+}
+
+func (s *stubMessageRouter) HandlerByTypeURL(typeURL string) baseapp.MsgServiceHandler {
+	s.handlerByURLCalled = true
+	s.gotTypeURL = typeURL
+	return s.handler
+}
+
+func TestEVMRejectingRouterHandlerRejectsEVMMsg(t *testing.T) {
+	stub := &stubMessageRouter{handler: func(sdk.Context, sdk.Msg) (*sdk.Result, error) { return &sdk.Result{}, nil }}
+	router := newEVMRejectingMessageRouter(stub)
+
+	handler := router.Handler(&evmtypes.MsgEthereumTx{})
+	require.NotNil(t, handler)
+	require.False(t, stub.handlerCalled, "EVM messages must not reach the wrapped router")
+
+	_, err := handler(sdk.Context{}, &evmtypes.MsgEthereumTx{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not allowed to be executed through authz")
+}
+
+func TestEVMRejectingRouterHandlerDelegatesNonEVMMsg(t *testing.T) {
+	sentinel := func(sdk.Context, sdk.Msg) (*sdk.Result, error) { return &sdk.Result{}, nil }
+	stub := &stubMessageRouter{handler: sentinel}
+	router := newEVMRejectingMessageRouter(stub)
+
+	msg := &banktypes.MsgSend{}
+	handler := router.Handler(msg)
+
+	require.NotNil(t, handler)
+	require.True(t, stub.handlerCalled)
+	require.Equal(t, msg, stub.gotMsg)
+}
+
+func TestEVMRejectingRouterHandlerByTypeURLRejectsEVM(t *testing.T) {
+	stub := &stubMessageRouter{handler: func(sdk.Context, sdk.Msg) (*sdk.Result, error) { return &sdk.Result{}, nil }}
+	router := newEVMRejectingMessageRouter(stub)
+
+	require.Nil(t, router.HandlerByTypeURL(evmMsgTypeURL))
+	require.False(t, stub.handlerByURLCalled, "EVM type URL must not reach the wrapped router")
+}
+
+func TestEVMRejectingRouterHandlerByTypeURLDelegatesNonEVM(t *testing.T) {
+	sentinel := func(sdk.Context, sdk.Msg) (*sdk.Result, error) { return &sdk.Result{}, nil }
+	stub := &stubMessageRouter{handler: sentinel}
+	router := newEVMRejectingMessageRouter(stub)
+
+	typeURL := sdk.MsgTypeURL(&banktypes.MsgSend{})
+	handler := router.HandlerByTypeURL(typeURL)
+
+	require.NotNil(t, handler)
+	require.True(t, stub.handlerByURLCalled)
+	require.Equal(t, typeURL, stub.gotTypeURL)
+}

--- a/app/keepers/authz_router_test.go
+++ b/app/keepers/authz_router_test.go
@@ -1,0 +1,77 @@
+//go:build test
+
+package keepers_test
+
+import (
+	"math/big"
+	"testing"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	sdkmath "cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	kiichain "github.com/kiichain/kiichain/v7/app"
+	"github.com/kiichain/kiichain/v7/app/apptesting"
+	apphelpers "github.com/kiichain/kiichain/v7/app/helpers"
+	kiiparams "github.com/kiichain/kiichain/v7/app/params"
+	tokenfactorytypes "github.com/kiichain/kiichain/v7/x/tokenfactory/types"
+)
+
+func newUnsignedEVMMsg(from sdk.AccAddress) *evmtypes.MsgEthereumTx {
+	to := gethcommon.BytesToAddress(apptesting.RandomAccountAddress().Bytes())
+	msg := evmtypes.NewTx(&evmtypes.EvmTxArgs{
+		ChainID:  big.NewInt(int64(kiichain.KiichainID)),
+		Nonce:    0,
+		To:       &to,
+		GasLimit: 21_000,
+		GasPrice: big.NewInt(0),
+		Amount:   big.NewInt(1),
+	})
+	msg.From = from.Bytes()
+	return msg
+}
+
+func TestAuthzRouterRejectsDirectMsgEthereumTx(t *testing.T) {
+	app, ctx := apphelpers.SetupWithContext(t)
+	grantee := apptesting.RandomAccountAddress()
+
+	_, err := app.AuthzKeeper.DispatchActions(ctx, grantee, []sdk.Msg{newUnsignedEVMMsg(grantee)})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not allowed to be executed through authz")
+}
+
+func TestAuthzRouterRejectsNestedMsgEthereumTx(t *testing.T) {
+	app, ctx := apphelpers.SetupWithContext(t)
+	grantee := apptesting.RandomAccountAddress()
+
+	inner := authz.NewMsgExec(grantee, []sdk.Msg{newUnsignedEVMMsg(grantee)})
+
+	_, err := app.AuthzKeeper.DispatchActions(ctx, grantee, []sdk.Msg{&inner})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not allowed to be executed through authz")
+}
+
+func TestAuthzRouterAllowsNonEVMMsg(t *testing.T) {
+	app, ctx := apphelpers.SetupWithContext(t)
+	grantee := apptesting.RandomAccountAddress()
+	recipient := apptesting.RandomAccountAddress()
+
+	fundAmount := sdkmath.NewInt(1_000)
+	sendAmount := sdkmath.NewInt(100)
+	coins := sdk.NewCoins(sdk.NewCoin(kiiparams.BaseDenom, fundAmount))
+	require.NoError(t, app.BankKeeper.MintCoins(ctx, tokenfactorytypes.ModuleName, coins))
+	require.NoError(t, app.BankKeeper.SendCoinsFromModuleToAccount(ctx, tokenfactorytypes.ModuleName, grantee, coins))
+
+	sendMsg := banktypes.NewMsgSend(grantee, recipient, sdk.NewCoins(sdk.NewCoin(kiiparams.BaseDenom, sendAmount)))
+
+	_, err := app.AuthzKeeper.DispatchActions(ctx, grantee, []sdk.Msg{sendMsg})
+	require.NoError(t, err)
+	require.Equal(t, sendAmount, app.BankKeeper.GetBalance(ctx, recipient, kiiparams.BaseDenom).Amount)
+}

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -224,7 +224,7 @@ func NewAppKeeper(
 	appKeepers.AuthzKeeper = authzkeeper.NewKeeper(
 		runtime.NewKVStoreService(appKeepers.keys[authzkeeper.StoreKey]),
 		appCodec,
-		bApp.MsgServiceRouter(),
+		newEVMRejectingMessageRouter(bApp.MsgServiceRouter()),
 		appKeepers.AccountKeeper,
 	)
 


### PR DESCRIPTION
# Description

This PR closes an EVM ante-bypass vector reachable through the authz module. Cosmos SDK's authz keeper unwraps `cosmos.authz.v1beta1.MsgExec` and dispatches the nested messages directly through the app message router, skipping kiichain's Cosmos ante handler. Because the EVM-specific protections (`RejectMessagesDecorator` and `AuthzLimiterDecorator`) only run in the ante path, a nested `cosmos.evm.vm.v1.MsgEthereumTx` could be routed into the EVM `MsgServer` outside of the EVM ante/nonce/fee/block-gas checks. This is exploitable on any execution path that dispatches authz without running the ante (e.g. gov proposal execution, CosmWasm contract dispatch, and the ICA host if it is ever re-enabled), and the no-grant self-grantee variant requires no authz grant since `MsgEthereumTx.From` can be spoofed independently of the recovered Ethereum signer.

The fix wraps the `baseapp.MessageRouter` passed into the `AuthzKeeper` with a guard that refuses to return a handler for `MsgEthereumTx` (and refuses it via `HandlerByTypeURL`, which also blocks creating authz grants for that type). The guard is scoped to the AuthzKeeper reference only, so baseapp tx routing and all other modules keep using the unwrapped router. Because nested `MsgExec`s re-enter the same guarded router at every level, this catches `MsgEthereumTx` at any nesting depth. There is no functional regression: executing `MsgEthereumTx` through authz was already rejected at the ante for normal transactions, so no legitimate path relied on it. The change is contained to kiichain; no changes to the EVM module are required.

Dependencies: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./app/...` passes on the repo's Go 1.24 toolchain.
- [x] Authz `MsgExec` wrapping `MsgEthereumTx` is rejected with `ErrUnauthorized` at dispatch (direct and nested), while non-EVM authz `MsgExec` continues to execute normally.

# PR Checklist:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`