### PR TITLE
fix: Feegrant Denomination Bypass via Post-Allowance Fee Conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Fix feegrant denomination bypass in the cosmos fee ante handler by converting the fee before consuming the grant, so `UseGrantedFees` is checked against the same coins later deducted (prevents a grantee from forcing the granter to pay in a non-granted fee-abstraction denom)
 - Refactor `PerformSetMetadata` in wasmbinding to delegate to `msgServer.SetDenomMetadata`, ensuring the `EnableSetMetadata` capability check is enforced
 - Ensure that `UpdateTokenMetadata.Decimals` matches the ERC20 or bank records
 - Fixed odd validation on tokenfactory change admin that blocked removing admin from the token

--- a/x/feeabstraction/ante/cosmos/fee.go
+++ b/x/feeabstraction/ante/cosmos/fee.go
@@ -107,20 +107,12 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 	// if feegranter set deduct fee from feegranter account.
 	// this works with only when feegrant enabled.
 	if feeGranter != nil {
-		feeGranterAddr := sdk.AccAddress(feeGranter)
-
-		// If feegranter is set, we need to check if the feegrant module is enabled
 		if dfd.feegrantKeeper == nil {
 			return sdkerrors.ErrInvalidRequest.Wrap("fee grants are not enabled")
-		} else if !bytes.Equal(feeGranterAddr, feePayer) {
-			err := dfd.feegrantKeeper.UseGrantedFees(ctx, feeGranterAddr, feePayer, fee, sdkTx.GetMsgs())
-			if err != nil {
-				return errorsmod.Wrapf(err, "%s does not allow to pay fees for %s", feeGranter, feePayer)
-			}
 		}
 
 		// If feegranter is set, we deduct the fees from the feegranter account
-		deductFeesFrom = feeGranterAddr
+		deductFeesFrom = sdk.AccAddress(feeGranter)
 	}
 
 	// Get the account of the fee payer
@@ -129,22 +121,31 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 		return sdkerrors.ErrUnknownAddress.Wrapf("fee payer address: %s does not exist", deductFeesFrom)
 	}
 
-	// Deduct the fees
+	// Apply the fee conversion from the fee abstraction module against the
+	// account that will actually pay, so the feegrant is validated and consumed
+	// using the same coins that are later deducted
 	var convertedFee sdk.Coins
 	if !fee.IsZero() {
-		// Apply the fee conversion from the fee abstraction module
-		// This is the only change from the original implementation
 		var err error
 		convertedFee, err = dfd.feeAbstractionKeeper.ConvertNativeFee(ctx, deductFeesFromAcc.GetAddress(), fee)
 		if err != nil {
 			return err
 		}
+	}
 
+	if feeGranter != nil && !bytes.Equal(deductFeesFrom, feePayer) {
+		err := dfd.feegrantKeeper.UseGrantedFees(ctx, deductFeesFrom, feePayer, convertedFee, sdkTx.GetMsgs())
+		if err != nil {
+			return errorsmod.Wrapf(err, "%s does not allow to pay fees for %s", feeGranter, feePayer)
+		}
+	}
+
+	if !convertedFee.IsZero() {
 		// Refresh info, it can't be nil since we checked it exists before
 		deductFeesFromAcc = dfd.accountKeeper.GetAccount(ctx, deductFeesFrom)
 
 		// Deduct the fees from the fee payer account
-		err = ante.DeductFees(dfd.bankKeeper, ctx, deductFeesFromAcc, convertedFee)
+		err := ante.DeductFees(dfd.bankKeeper, ctx, deductFeesFromAcc, convertedFee)
 		if err != nil {
 			return err
 		}

--- a/x/feeabstraction/ante/cosmos/fee.go
+++ b/x/feeabstraction/ante/cosmos/fee.go
@@ -121,9 +121,6 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 		return sdkerrors.ErrUnknownAddress.Wrapf("fee payer address: %s does not exist", deductFeesFrom)
 	}
 
-	// Apply the fee conversion from the fee abstraction module against the
-	// account that will actually pay, so the feegrant is validated and consumed
-	// using the same coins that are later deducted
 	var convertedFee sdk.Coins
 	if !fee.IsZero() {
 		var err error
@@ -136,7 +133,7 @@ func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee 
 	if feeGranter != nil && !bytes.Equal(deductFeesFrom, feePayer) {
 		err := dfd.feegrantKeeper.UseGrantedFees(ctx, deductFeesFrom, feePayer, convertedFee, sdkTx.GetMsgs())
 		if err != nil {
-			return errorsmod.Wrapf(err, "%s does not allow to pay fees for %s", feeGranter, feePayer)
+			return errorsmod.Wrapf(err, "%s does not allow to pay fees for %s", sdk.AccAddress(deductFeesFrom).String(), sdk.AccAddress(feePayer).String())
 		}
 	}
 

--- a/x/feeabstraction/ante/cosmos/fee_internal_test.go
+++ b/x/feeabstraction/ante/cosmos/fee_internal_test.go
@@ -1,0 +1,130 @@
+package cosmos
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+	protov2 "google.golang.org/protobuf/proto"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	antetestutil "github.com/cosmos/cosmos-sdk/x/auth/ante/testutil"
+	authtestutil "github.com/cosmos/cosmos-sdk/x/auth/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// feeTxStub is a minimal sdk.FeeTx used to drive checkDeductFee without
+// building a full transaction or bootstrapping the app.
+type feeTxStub struct {
+	fee        sdk.Coins
+	gas        uint64
+	feePayer   []byte
+	feeGranter []byte
+}
+
+func (f feeTxStub) GetMsgs() []sdk.Msg                    { return nil }
+func (f feeTxStub) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+func (f feeTxStub) GetGas() uint64                        { return f.gas }
+func (f feeTxStub) GetFee() sdk.Coins                     { return f.fee }
+func (f feeTxStub) FeePayer() []byte                      { return f.feePayer }
+func (f feeTxStub) FeeGranter() []byte                    { return f.feeGranter }
+
+// feeAbstractionStub is a stub of the fee abstraction keeper that returns a
+// fixed converted fee (or error) regardless of input.
+type feeAbstractionStub struct {
+	converted sdk.Coins
+	err       error
+}
+
+func (f feeAbstractionStub) ConvertNativeFee(_ sdk.Context, _ sdk.AccAddress, _ sdk.Coins) (sdk.Coins, error) {
+	return f.converted, f.err
+}
+
+// TestCheckDeductFeeInternal exercises the post-conversion feegrant flow in
+// checkDeductFee with fully mocked keepers. It runs without the "test" build
+// tag (no app bootstrap), so the CI coverage job actually records it.
+func TestCheckDeductFeeInternal(t *testing.T) {
+	payer := sdk.AccAddress([]byte("payeraddress00000001"))
+	granter := sdk.AccAddress([]byte("granteraddress000001"))
+
+	nativeFee := sdk.NewCoins(sdk.NewInt64Coin("akii", 1000))
+	convertedFee := sdk.NewCoins(sdk.NewInt64Coin("uconv", 500))
+
+	testCases := []struct {
+		name        string
+		feeGranter  []byte
+		converted   sdk.Coins
+		convertErr  error
+		grantErr    error
+		deductErr   error
+		errContains string
+	}{
+		{
+			name:       "success - converts, consumes grant and deducts",
+			feeGranter: granter,
+			converted:  convertedFee,
+		},
+		{
+			name:        "fail - conversion error is returned",
+			feeGranter:  granter,
+			convertErr:  errors.New("conversion boom"),
+			errContains: "conversion boom",
+		},
+		{
+			name:        "fail - feegrant denied is wrapped",
+			feeGranter:  granter,
+			converted:   convertedFee,
+			grantErr:    errors.New("fee-grant not found"),
+			errContains: "does not allow to pay fees",
+		},
+		{
+			name:        "fail - deduction error is returned",
+			feeGranter:  nil,
+			converted:   convertedFee,
+			deductErr:   errors.New("insufficient funds"),
+			errContains: "insufficient funds",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			accountKeeper := antetestutil.NewMockAccountKeeper(ctrl)
+			feegrantKeeper := antetestutil.NewMockFeegrantKeeper(ctrl)
+			bankKeeper := authtestutil.NewMockBankKeeper(ctrl)
+
+			deductFrom := payer
+			if tc.feeGranter != nil {
+				deductFrom = sdk.AccAddress(tc.feeGranter)
+			}
+			acc := authtypes.NewBaseAccountWithAddress(deductFrom)
+
+			accountKeeper.EXPECT().GetModuleAddress(authtypes.FeeCollectorName).Return(sdk.AccAddress([]byte("feecollector00000001"))).AnyTimes()
+			accountKeeper.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(acc).AnyTimes()
+			feegrantKeeper.EXPECT().UseGrantedFees(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.grantErr).AnyTimes()
+			bankKeeper.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.deductErr).AnyTimes()
+
+			dfd := NewDeductFeeDecorator(
+				accountKeeper,
+				bankKeeper,
+				feegrantKeeper,
+				feeAbstractionStub{converted: tc.converted, err: tc.convertErr},
+				func(sdk.Context, sdk.Tx) (sdk.Coins, int64, error) { return nil, 0, nil },
+			)
+
+			ctx := sdk.Context{}.WithEventManager(sdk.NewEventManager())
+			tx := feeTxStub{fee: nativeFee, gas: 1_000_000, feePayer: payer, feeGranter: tc.feeGranter}
+
+			err := dfd.checkDeductFee(ctx, tx, nativeFee)
+			if tc.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x/feeabstraction/ante/cosmos/fee_test.go
+++ b/x/feeabstraction/ante/cosmos/fee_test.go
@@ -244,11 +244,62 @@ func TestDeductFeeDecorator(t *testing.T) {
 			},
 		},
 		{
-			name:        "fail - unauthorized fee grant",
+			name: "fail - unauthorized fee grant",
+			malleate: func(ctx sdk.Context) {
+				// Fund the granter so fee conversion is a no-op and the missing grant is what fails
+				err := app.BankKeeper.MintCoins(ctx, evmtypes.ModuleName, sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)))
+				require.NoError(t, err)
+				err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, feeGranter, sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)))
+				require.NoError(t, err)
+			},
 			feeGranter:  feeGranter,
 			fee:         sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)),
 			expected:    sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)),
 			errContains: "fee-grant not found",
+		},
+		{
+			name: "fail - feegrant denom bypass blocked when grant is akii but conversion picks erc20",
+			malleate: func(ctx sdk.Context) {
+				err := app.Erc20Keeper.SetToken(ctx, erc20types.TokenPair{
+					Erc20Address:  MockErc20Address,
+					Denom:         MockErc20Denom,
+					Enabled:       true,
+					ContractOwner: erc20types.OWNER_UNSPECIFIED,
+				})
+				require.NoError(t, err)
+
+				err = app.FeeAbstractionKeeper.FeeTokens.Set(ctx, *types.NewFeeTokenMetadataCollection(
+					types.NewFeeTokenMetadata(
+						MockErc20Denom,
+						MockErc20Denom,
+						18,
+						MockErc20Price,
+					),
+				))
+				require.NoError(t, err)
+
+				// Granter holds only the enabled fee token, no native akii
+				err = app.BankKeeper.MintCoins(ctx, evmtypes.ModuleName, sdk.NewCoins(sdk.NewInt64Coin(MockErc20Denom, DefaultMinFeeValue*10)))
+				require.NoError(t, err)
+				err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, feeGranter, sdk.NewCoins(sdk.NewInt64Coin(MockErc20Denom, DefaultMinFeeValue*10)))
+				require.NoError(t, err)
+
+				// Grant authorizes native akii only
+				err = app.FeeGrantKeeper.GrantAllowance(ctx, feeGranter, founder, &feegrant.BasicAllowance{
+					SpendLimit: sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)),
+					Expiration: nil,
+				})
+				require.NoError(t, err)
+			},
+			feeGranter:  feeGranter,
+			fee:         sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)),
+			expected:    sdk.NewCoins(sdk.NewInt64Coin(MockErc20Denom, DefaultMinFeeValue*10)),
+			errContains: "does not allow to pay fees",
+			postCheck: func(ctx sdk.Context) {
+				// The granter's enabled fee token must be untouched
+				balance := app.BankKeeper.GetBalance(ctx, feeGranter, MockErc20Denom)
+				require.Equal(t, DefaultMinFeeValue*10, balance.Amount.Int64())
+			},
 		},
 	}
 

--- a/x/feeabstraction/ante/cosmos/fee_test.go
+++ b/x/feeabstraction/ante/cosmos/fee_test.go
@@ -1,3 +1,5 @@
+//go:build test
+
 package cosmos_test
 
 import (
@@ -246,7 +248,6 @@ func TestDeductFeeDecorator(t *testing.T) {
 		{
 			name: "fail - unauthorized fee grant",
 			malleate: func(ctx sdk.Context) {
-				// Fund the granter so fee conversion is a no-op and the missing grant is what fails
 				err := app.BankKeeper.MintCoins(ctx, evmtypes.ModuleName, sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)))
 				require.NoError(t, err)
 				err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, feeGranter, sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)))
@@ -278,13 +279,11 @@ func TestDeductFeeDecorator(t *testing.T) {
 				))
 				require.NoError(t, err)
 
-				// Granter holds only the enabled fee token, no native akii
 				err = app.BankKeeper.MintCoins(ctx, evmtypes.ModuleName, sdk.NewCoins(sdk.NewInt64Coin(MockErc20Denom, DefaultMinFeeValue*10)))
 				require.NoError(t, err)
 				err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, evmtypes.ModuleName, feeGranter, sdk.NewCoins(sdk.NewInt64Coin(MockErc20Denom, DefaultMinFeeValue*10)))
 				require.NoError(t, err)
 
-				// Grant authorizes native akii only
 				err = app.FeeGrantKeeper.GrantAllowance(ctx, feeGranter, founder, &feegrant.BasicAllowance{
 					SpendLimit: sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)),
 					Expiration: nil,
@@ -293,10 +292,9 @@ func TestDeductFeeDecorator(t *testing.T) {
 			},
 			feeGranter:  feeGranter,
 			fee:         sdk.NewCoins(sdk.NewInt64Coin("akii", DefaultMinFeeValue)),
-			expected:    sdk.NewCoins(sdk.NewInt64Coin(MockErc20Denom, DefaultMinFeeValue*10)),
+			expected:    sdk.NewCoins(),
 			errContains: "does not allow to pay fees",
 			postCheck: func(ctx sdk.Context) {
-				// The granter's enabled fee token must be untouched
 				balance := app.BankKeeper.GetBalance(ctx, feeGranter, MockErc20Denom)
 				require.Equal(t, DefaultMinFeeValue*10, balance.Amount.Int64())
 			},


### PR DESCRIPTION
# Description

When you grant someone permission to pay fees on your behalf, you grant them a specific token (e.g. `akii`). The ante handler was checking the grant against `akii`, but *then* converting the fee and actually deducting a **different** token (e.g. an enabled ERC20) from the granter when the granter had no `akii`. So a grant for `akii` could end up draining the granter's ERC20/stablecoin balance — a token they never authorized.

**The fix:** reorder the steps in `checkDeductFee` so the fee is converted **first** (against the granter's account), and then the feegrant is checked and consumed using the **actual converted fee** that will be deducted. Now the token checked by the grant is always the same token that gets spent.

Files changed:
- `x/feeabstraction/ante/cosmos/fee.go`

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./x/feeabstraction/...` passes
- [x] Existing ante handler unit tests pass (`make test-unit`)
- [x] Manual: granter with `0 akii` + an enabled ERC20 fee token and an `akii`-only feegrant — tx now fails the grant check instead of silently draining the ERC20

# PR Checklist:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`