### PR TITLE
fix: prevent rewards BeginBlocker chain halt on bank transfer failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - Indexed admins to reduce query space on tokenfactory denom queries
 - Fix native token supply inflation from the stateful precompiles by wrapping the account address codec (`evmAddressCodec`) to reject non-20-byte accounts (e.g. a 32-byte bech32 withdraw, module, or CosmWasm contract address) at decode time, preventing such addresses from being truncated and minted a duplicate balance when mirrored into the EVM StateDB
 - Close governance vote minimum-stake bypass in `GovVoteDecorator` by enforcing the stake check on `MsgVoteWeighted` (`govv1` and `govv1beta1`) and recursing into nested `authz.MsgExec` messages so wrapped votes can no longer skip the requirement
+- Prevent a chain halt in the rewards `BeginBlocker` by routing `SendCoinsFromModuleToModule` failures through `haltSchedule` (graceful schedule deactivation) instead of returning a fatal error, matching the other reward release error paths
+- Add a `ValidateModuleAccounting` check (rewards module bank balance must cover the `CommunityPool`) and run it at genesis and during the v7.2 upgrade to surface accounting/bank divergences early
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Fix native token supply inflation from the stateful precompiles by wrapping the account address codec (`evmAddressCodec`) to reject non-20-byte accounts (e.g. a 32-byte bech32 withdraw, module, or CosmWasm contract address) at decode time, preventing such addresses from being truncated and minted a duplicate balance when mirrored into the EVM StateDB
 - Close governance vote minimum-stake bypass in `GovVoteDecorator` by enforcing the stake check on `MsgVoteWeighted` (`govv1` and `govv1beta1`) and recursing into nested `authz.MsgExec` messages so wrapped votes can no longer skip the requirement
 - Prevent a chain halt in the rewards `BeginBlocker` by routing `SendCoinsFromModuleToModule` failures through `haltSchedule` (graceful schedule deactivation) instead of returning a fatal error, matching the other reward release error paths
-- Add a `ValidateModuleAccounting` check (rewards module bank balance must cover the `CommunityPool`) and run it at genesis and during the v7.2 upgrade to surface accounting/bank divergences early
+- Add a `ValidateModuleAccounting` check (rewards module bank balance must cover the `CommunityPool`) and run it at genesis to surface accounting/bank divergences early
 
 ### Removed
 

--- a/app/upgrades/v7_2/upgrade.go
+++ b/app/upgrades/v7_2/upgrade.go
@@ -17,7 +17,7 @@ import (
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
-	_ *keepers.AppKeepers,
+	appKeepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(c)
@@ -27,6 +27,10 @@ func CreateUpgradeHandler(
 		vm, err := mm.RunMigrations(ctx, configurator, vm)
 		if err != nil {
 			return vm, err
+		}
+
+		if err := appKeepers.RewardsKeeper.ValidateModuleAccounting(ctx); err != nil {
+			ctx.Logger().Error("rewards module accounting invariant violated during upgrade", "error", err)
 		}
 
 		ctx.Logger().Info("Upgrade v7.2.0 complete")

--- a/app/upgrades/v7_2/upgrade.go
+++ b/app/upgrades/v7_2/upgrade.go
@@ -17,7 +17,7 @@ import (
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
-	appKeepers *keepers.AppKeepers,
+	_ *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(c)
@@ -27,10 +27,6 @@ func CreateUpgradeHandler(
 		vm, err := mm.RunMigrations(ctx, configurator, vm)
 		if err != nil {
 			return vm, err
-		}
-
-		if err := appKeepers.RewardsKeeper.ValidateModuleAccounting(ctx); err != nil {
-			ctx.Logger().Error("rewards module accounting invariant violated during upgrade", "error", err)
 		}
 
 		ctx.Logger().Info("Upgrade v7.2.0 complete")

--- a/x/rewards/keeper/abci.go
+++ b/x/rewards/keeper/abci.go
@@ -71,7 +71,7 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) error {
 
 	// Send to distribution pool
 	if err := k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.feeCollectorName, coinsToDistribute); err != nil {
-		return err
+		return k.haltSchedule(ctx, schedule, fmt.Errorf("failed to send rewards to fee collector: %w", err))
 	}
 
 	// Deduct from RewardPool using SafeSub so a divergence cannot panic the chain.

--- a/x/rewards/keeper/abci_test.go
+++ b/x/rewards/keeper/abci_test.go
@@ -137,6 +137,30 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 			expectedChangeAmount: sdk.NewCoin(denom, math.ZeroInt()),
 		},
 		{
+			name: "bank transfer failure - halts schedule gracefully",
+			initialSchedule: types.ReleaseSchedule{
+				Active:          true,
+				TotalAmount:     sdk.NewCoin(denom, math.NewInt(1000000)),
+				ReleasedAmount:  sdk.NewCoin(denom, math.ZeroInt()),
+				LastReleaseTime: now,
+				EndTime:         now.Add(time.Hour * 2),
+			},
+			// Accounting claims 1,000,000 is available but the module account only
+			// holds the 100,000 funded above, so the 500,000 release transfer fails
+			// and the schedule must be halted instead of aborting the block.
+			initialPool: sdk.NewDecCoins(sdk.NewDecCoin(denom, math.NewInt(1000000))),
+			blockTime:   now.Add(time.Hour),
+			expectedSchedule: types.ReleaseSchedule{
+				Active:          false,
+				TotalAmount:     sdk.NewCoin(denom, math.NewInt(1000000)),
+				ReleasedAmount:  sdk.NewCoin(denom, math.ZeroInt()),
+				LastReleaseTime: now,
+				EndTime:         now.Add(time.Hour * 2),
+			},
+			expectedChange:       true,
+			expectedChangeAmount: sdk.NewCoin(denom, math.ZeroInt()),
+		},
+		{
 			name: "end time equal to last release time - releases full remaining",
 			initialSchedule: types.ReleaseSchedule{
 				Active:          true,

--- a/x/rewards/keeper/genesis.go
+++ b/x/rewards/keeper/genesis.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/kiichain/kiichain/v7/x/rewards/types"
 )
@@ -21,19 +20,11 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data types.GenesisState) {
 		panic(err)
 	}
 
-	// Consistency check: warn if the module bank balance for the configured denom
-	// does not match the CommunityPool accounting
-	denom := data.Params.TokenDenom
-	moduleAddr := authtypes.NewModuleAddress(types.ModuleName)
-	bankBalance := k.bankKeeper.GetBalance(ctx, moduleAddr, denom)
-	poolAmount := data.RewardPool.CommunityPool.AmountOf(denom).TruncateInt()
-	if !bankBalance.Amount.Equal(poolAmount) {
-		k.Logger(ctx).Error(
-			"rewards module bank balance does not match CommunityPool accounting at genesis",
-			"denom", denom,
-			"bank_balance", bankBalance.Amount,
-			"community_pool", poolAmount,
-		)
+	// Consistency check: warn if the module bank balance cannot cover the
+	// CommunityPool accounting. This is only logged because module InitGenesis
+	// ordering may fund the module account after this runs.
+	if err := k.ValidateModuleAccounting(ctx); err != nil {
+		k.Logger(ctx).Error("rewards module accounting mismatch at genesis", "error", err)
 	}
 }
 

--- a/x/rewards/keeper/invariants.go
+++ b/x/rewards/keeper/invariants.go
@@ -1,0 +1,32 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/kiichain/kiichain/v7/x/rewards/types"
+)
+
+// ValidateModuleAccounting checks that the rewards module account holds at least the coins tracked by the CommunityPool
+func (k Keeper) ValidateModuleAccounting(ctx sdk.Context) error {
+	rewardPool, err := k.RewardPool.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	moduleAddr := authtypes.NewModuleAddress(types.ModuleName)
+	for _, poolCoin := range rewardPool.CommunityPool {
+		required := poolCoin.Amount.TruncateInt()
+		balance := k.bankKeeper.GetBalance(ctx, moduleAddr, poolCoin.Denom).Amount
+		if balance.LT(required) {
+			return fmt.Errorf(
+				"rewards module accounting mismatch for %s: bank balance %s < community pool %s",
+				poolCoin.Denom, balance, required,
+			)
+		}
+	}
+
+	return nil
+}

--- a/x/rewards/keeper/invariants_test.go
+++ b/x/rewards/keeper/invariants_test.go
@@ -1,0 +1,29 @@
+package keeper_test
+
+import (
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/kiichain/kiichain/v7/x/rewards/types"
+)
+
+func (suite *KeeperTestSuite) TestValidateModuleAccounting() {
+	denom := types.DefaultParams().TokenDenom
+
+	// An empty community pool is trivially consistent
+	suite.Require().NoError(suite.App.RewardsKeeper.RewardPool.Set(suite.Ctx, types.RewardPool{}))
+	suite.Require().NoError(suite.App.RewardsKeeper.ValidateModuleAccounting(suite.Ctx))
+
+	// Funding the pool moves coins into the module account, so balance matches accounting
+	err := suite.App.RewardsKeeper.FundCommunityPool(suite.Ctx, sdk.NewCoin(denom, math.NewInt(1000)), suite.TestAccs[0])
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.App.RewardsKeeper.ValidateModuleAccounting(suite.Ctx))
+
+	// Inflating the accounting beyond the module balance must break the invariant
+	pool, err := suite.App.RewardsKeeper.RewardPool.Get(suite.Ctx)
+	suite.Require().NoError(err)
+	pool.CommunityPool = pool.CommunityPool.Add(sdk.NewDecCoin(denom, math.NewInt(1)))
+	suite.Require().NoError(suite.App.RewardsKeeper.RewardPool.Set(suite.Ctx, pool))
+	suite.Require().Error(suite.App.RewardsKeeper.ValidateModuleAccounting(suite.Ctx))
+}


### PR DESCRIPTION
# Description

Fixes a chain-liveness bug in the `x/rewards` module. In `BeginBlocker`, a failed `SendCoinsFromModuleToModule` (rewards module to fee collector) returned the error directly, which aborts `FinalizeBlock` and halts every validator. The other failure paths in the same function (`CalculateReward` error, insufficient community pool, negative `SafeSub`) already deactivate the schedule gracefully via `haltSchedule`; the bank transfer was the one path that didn't. The trigger is a divergence between the rewards module's internal `CommunityPool` accounting and the module account's actual bank balance (e.g. misconfigured genesis or prior state inconsistency).

Changes:

- Route the bank transfer failure through `haltSchedule`, so a transfer error deactivates the release schedule and the block still commits (matches the other error paths). The transfer happens before any `RewardPool`/schedule state writes, so no partial accounting is persisted on failure.
- Add `Keeper.ValidateModuleAccounting` (module bank balance must cover the `CommunityPool`) as a single source of truth, and run it at **genesis** (logged warning, module InitGenesis ordering can fund the account after this runs, so a hard failure would false positive) and during the **v7.2 upgrade** handler (logged after migrations) to surface an accounting/bank divergence early.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] test (For updates on tests)

# How Has This Been Tested?

- [x] `go test -tags=test -run 'TestKeeperTestSuite/TestEndBlocker' ./x/rewards/keeper/...` — added a `"bank transfer failure - halts schedule gracefully"` case that sets `CommunityPool` accounting above the module account's actual balance, forcing the release transfer to fail; asserts `BeginBlocker` returns no error and the schedule becomes inactive (this case fails without the fix).
- [x] `go test -tags=test -run 'TestKeeperTestSuite/TestValidateModuleAccounting' ./x/rewards/keeper/...` — covers empty pool (ok), funded pool matching balance (ok), and accounting inflated beyond balance (error).
- [x] `go build ./x/rewards/... ./app/...` — compiles cleanly.

# PR Checklist:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix` (golangci-lint v2.7.2, 0 issues on `./x/rewards/...` and `./app/upgrades/...`)