### PR TITLE
fix: Reward Pool Exhaustion via Forced Minimum 1-Unit-Per-Block Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Remove the forced minimum 1-unit-per-block reward release in `CalculateReward` and skip (instead of deactivating) sub-unit blocks in the rewards `BeginBlocker`, so the proportional share accumulates and the pool follows the configured schedule independent of block time (previously a 10-year, 1M-unit schedule drained in ~12 days at the 1s target block time and ~28 days at the current ~2.4s rate, regardless of the configured duration)
 - Reject `MsgEthereumTx` from being dispatched through the authz keeper (including when nested inside `authz.MsgExec`), closing an EVM ante bypass on message-router execution paths that skip the ante handler
 - Fix feegrant denomination bypass in the cosmos fee ante handler by converting the fee before consuming the grant, so `UseGrantedFees` is checked against the same coins later deducted (prevents a grantee from forcing the granter to pay in a non-granted fee-abstraction denom)
 - Refactor `PerformSetMetadata` in wasmbinding to delegate to `msgServer.SetDenomMetadata`, ensuring the `EnableSetMetadata` capability check is enforced

--- a/x/rewards/keeper/abci.go
+++ b/x/rewards/keeper/abci.go
@@ -47,10 +47,12 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) error {
 		return k.haltSchedule(ctx, schedule, err)
 	}
 
-	// If nothing to distribute, sets up as inactive for early exit next time
 	if amountToDistribute.IsZero() {
-		schedule.Active = false
-		return k.ReleaseSchedule.Set(ctx, schedule)
+		if schedule.ReleasedAmount.IsGTE(schedule.TotalAmount) {
+			schedule.Active = false
+			return k.ReleaseSchedule.Set(ctx, schedule)
+		}
+		return nil
 	}
 
 	// Get the current RewardPool from state

--- a/x/rewards/keeper/abci_test.go
+++ b/x/rewards/keeper/abci_test.go
@@ -161,6 +161,27 @@ func (suite *KeeperTestSuite) TestEndBlocker() {
 			expectedChangeAmount: sdk.NewCoin(denom, math.ZeroInt()),
 		},
 		{
+			name: "sub-unit release - skips without halting or releasing",
+			initialSchedule: types.ReleaseSchedule{
+				Active:          true,
+				TotalAmount:     sdk.NewCoin(denom, math.NewInt(1000000)),
+				ReleasedAmount:  sdk.NewCoin(denom, math.ZeroInt()),
+				LastReleaseTime: now,
+				EndTime:         now.Add(time.Hour * 24 * 365 * 10),
+			},
+			initialPool: sdk.NewDecCoins(sdk.NewDecCoin(denom, math.NewInt(1000000))),
+			blockTime:   now.Add(time.Second),
+			expectedSchedule: types.ReleaseSchedule{
+				Active:          true,
+				TotalAmount:     sdk.NewCoin(denom, math.NewInt(1000000)),
+				ReleasedAmount:  sdk.NewCoin(denom, math.ZeroInt()),
+				LastReleaseTime: now,
+				EndTime:         now.Add(time.Hour * 24 * 365 * 10),
+			},
+			expectedChange:       true,
+			expectedChangeAmount: sdk.NewCoin(denom, math.ZeroInt()),
+		},
+		{
 			name: "end time equal to last release time - releases full remaining",
 			initialSchedule: types.ReleaseSchedule{
 				Active:          true,

--- a/x/rewards/types/reward.go
+++ b/x/rewards/types/reward.go
@@ -36,8 +36,6 @@ func CalculateReward(blockTime time.Time, schedule ReleaseSchedule) (sdk.Coin, e
 	// Truncate to int, it will be a coin amt after all
 	amountToRelease := math.LegacyNewDecFromInt(remaining.Amount).Mul(releaseProportion).TruncateInt()
 
-	// Make sure at least one coin will be distributed if there is still a distribution to happen
-	amountToRelease = math.MaxInt(amountToRelease, math.NewInt(1))
 	// Cap at remaining amount
 	amountToRelease = math.MinInt(amountToRelease, remaining.Amount)
 

--- a/x/rewards/types/reward_test.go
+++ b/x/rewards/types/reward_test.go
@@ -155,3 +155,20 @@ func TestCalculateReward(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateRewardNoForcedMinimum(t *testing.T) {
+	now := time.Now()
+	denom := "akii"
+
+	schedule := types.ReleaseSchedule{
+		TotalAmount:     sdk.NewCoin(denom, math.NewInt(1000000)),
+		ReleasedAmount:  sdk.NewCoin(denom, math.ZeroInt()),
+		LastReleaseTime: now,
+		EndTime:         now.Add(time.Hour * 24 * 365 * 10),
+		Active:          true,
+	}
+
+	result, err := types.CalculateReward(now.Add(time.Second), schedule)
+	require.NoError(t, err)
+	require.True(t, result.Amount.IsZero(), "expected zero release, got %s", result.Amount)
+}


### PR DESCRIPTION
# Description

Fixes reward-pool exhaustion caused by a forced minimum release in the `x/rewards` module (audit finding F-2026-17887). `CalculateReward` forced at least one token unit per block (`math.MaxInt(amountToRelease, 1)`) even when the proportional linear share for that block rounded down to zero. On short block times this drains the pool far faster than the configured schedule intends — a 10-year, 1M-unit schedule empties in ~12 days at KiiChain's ~1s design target and ~28 days at the current ~2.4s live block rate, regardless of the configured duration.

Changes:

- `x/rewards/types/reward.go` — remove the forced 1-unit-per-block minimum; the proportional share now truncates honestly (and can be zero).
- `x/rewards/keeper/abci.go` — when nothing is due this block, only deactivate the schedule once it is fully released (`ReleasedAmount >= TotalAmount`); otherwise skip without advancing `LastReleaseTime` so the sub-unit fraction accumulates into a later block. This is required because `BeginBlocker` previously deactivated the schedule on a zero amount, so simply removing the minimum would have killed the schedule on the first sub-unit block.

Net effect: the release follows the configured linear schedule independent of block time. A unit is released roughly every `(EndTime - LastReleaseTime) / remaining`, reproducing the intended curve without any block-time-specific tuning.

Dependencies: none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] test (For updates on tests)

# How Has This Been Tested?

- [x] `go test -tags=test ./x/rewards/...` — all rewards unit tests pass (keeper + types).
- [x] `x/rewards/types/reward_test.go` — added `TestCalculateRewardNoForcedMinimum`, asserting a 1s block of a 10-year / 1M-unit schedule releases exactly zero (no forced minimum).
- [x] `x/rewards/keeper/abci_test.go` — added `"sub-unit release - skips without halting or releasing"`, asserting the schedule stays active with no release and an unchanged `LastReleaseTime` (this case fails under the old forced-minimum behavior).
- [x] `go build ./x/rewards/...` — compiles cleanly.

# PR Checklist:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix` (golangci-lint v2.7.2, 0 issues on `./x/rewards/...`)