### PR TITLE
fix(rewards): ChangeSchedule checks net amount instead of total

### DIFF
--- a/x/rewards/keeper/msg_server.go
+++ b/x/rewards/keeper/msg_server.go
@@ -91,8 +91,10 @@ func (k msgServer) ChangeSchedule(ctx context.Context, msg *types.MsgChangeSched
 		return nil, fmt.Errorf("invalid schedule: %w", err)
 	}
 
-	// Check available funds
-	if err := k.fundsAvailable(sdkCtx, schedule.TotalAmount); err != nil {
+	// Check available funds: only require pool to cover the remaining (unreleased) amount,
+	// not the full TotalAmount (which may have been partially released already).
+	netAmount := schedule.TotalAmount.Sub(schedule.ReleasedAmount)
+	if err := k.fundsAvailable(sdkCtx, netAmount); err != nil {
 		return nil, fmt.Errorf("insufficient funds: %w", err)
 	}
 


### PR DESCRIPTION
## Description

Fixes #338 - Broken ChangeSchedule function.

The `ChangeSchedule` function in the `x/rewards` module was checking funds availability against the **full** `TotalAmount`, ignoring already-released tokens. This prevented governance from updating a schedule after partial release, even when the pool held sufficient funds to cover the remaining balance.

### The Bug

```go
// Before (buggy):
if err := k.fundsAvailable(sdkCtx, schedule.TotalAmount); err != nil {
```

If `TotalAmount=1000` and `ReleasedAmount=900`, the function required `1000` in the pool even though only `100` remained to be paid.

### The Fix

```go
// After (fixed):
netAmount := schedule.TotalAmount.Sub(schedule.ReleasedAmount)
if err := k.fundsAvailable(sdkCtx, netAmount); err != nil {
```

Now only the **unreleased** portion is checked against the community pool.

### Validation

- `ReleasedAmount ≤ TotalAmount` is already enforced by `validateSchedule()` on line 91-94
- Denom consistency between TotalAmount and ReleasedAmount is validated on line 83-86
- The `Sub()` operation is safe because of these pre-conditions

### Related

- Issue: https://github.com/KiiChain/kiichain/issues/338
- E2E test demonstrating the bug: `TestRewardsChangeScheduleOverStrictFundsCheckE2E`