### PR TITLE
fix: EIP-7702 Delegated EOAs Permanently Locked Out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Allow EIP-7702 delegated EOAs to send direct EVM transactions by exempting delegation-designator code from the externally-owned-account-only check in `VerifyIfAccountExists`, so accounts that delegate via `SetCodeTx` can still manage (and revoke) their own delegation without a sponsored transaction
 - Remove the forced minimum 1-unit-per-block reward release in `CalculateReward` and skip (instead of deactivating) sub-unit blocks in the rewards `BeginBlocker`, so the proportional share accumulates and the pool follows the configured schedule independent of block time (previously a 10-year, 1M-unit schedule drained in ~12 days at the 1s target block time and ~28 days at the current ~2.4s rate, regardless of the configured duration)
 - Reject `MsgEthereumTx` from being dispatched through the authz keeper (including when nested inside `authz.MsgExec`), closing an EVM ante bypass on message-router execution paths that skip the ante handler
 - Fix feegrant denomination bypass in the cosmos fee ante handler by converting the fee before consuming the grant, so `UseGrantedFees` is checked against the same coins later deducted (prevents a grantee from forcing the granter to pay in a non-granted fee-abstraction denom)

--- a/x/feeabstraction/ante/evm/account_verification.go
+++ b/x/feeabstraction/ante/evm/account_verification.go
@@ -24,15 +24,20 @@ import (
 func VerifyIfAccountExists(
 	ctx sdk.Context,
 	accountKeeper anteinterfaces.AccountKeeper,
+	evmKeeper anteinterfaces.EVMKeeper,
 	account *statedb.Account,
 	from common.Address,
 ) error {
 	// Only EOA are allowed to send transactions.
 	if account != nil && account.HasCodeHash() {
-		return errorsmod.Wrapf(
-			errortypes.ErrInvalidType,
-			"the sender is not EOA: address %s", from,
-		)
+		code := evmKeeper.GetCode(ctx, common.BytesToHash(account.CodeHash))
+		_, delegated := ethtypes.ParseDelegation(code)
+		if len(code) > 0 && !delegated {
+			return errorsmod.Wrapf(
+				errortypes.ErrInvalidType,
+				"the sender is not EOA: address %s", from,
+			)
+		}
 	}
 
 	// Check if the account is nil, if so, create a new account

--- a/x/feeabstraction/ante/evm/mono_decorator.go
+++ b/x/feeabstraction/ante/evm/mono_decorator.go
@@ -195,6 +195,7 @@ func (md MonoDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 	if err := VerifyIfAccountExists(
 		ctx,
 		md.accountKeeper,
+		md.evmKeeper,
 		account,
 		fromAddr,
 	); err != nil {

--- a/x/feeabstraction/ante/evm/mono_decorator_test.go
+++ b/x/feeabstraction/ante/evm/mono_decorator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
@@ -366,11 +367,15 @@ func TestMonoDecorator(t *testing.T) {
 				fromAddr := keys.GetKey(0).Addr
 
 				// Create a contract account
-				// To define as a contract we need to set the code hash
+				// To define as a contract we need to store code and set the matching code hash
+				code := []byte("contract code")
+				codeHash := crypto.Keccak256Hash(code)
+				app.EVMKeeper.SetCode(ctx, codeHash.Bytes(), code)
+
 				err = app.EVMKeeper.SetAccount(ctx, fromAddr, statedb.Account{
 					Nonce:    0,
 					Balance:  uint256.NewInt(1000000),
-					CodeHash: []byte("contract code"),
+					CodeHash: codeHash.Bytes(),
 				})
 				require.NoError(t, err)
 
@@ -379,6 +384,35 @@ func TestMonoDecorator(t *testing.T) {
 			gasLimit:    20000000,
 			gasPrice:    big.NewInt(1000000),
 			errContains: "the sender is not EOA",
+		},
+		{
+			name: "success - account has EIP-7702 delegation code",
+			malleate: func(ctx sdk.Context) sdk.Context {
+				// Set the EVM account beforehand
+				fromAddr := keys.GetKey(0).Addr
+
+				// Build an EIP-7702 delegation designator (0xef0100 || address)
+				// and store it as the account code
+				delegation := append(gethtypes.DelegationPrefix, common.HexToAddress("0x1111111111111111111111111111111111111111").Bytes()...)
+				codeHash := crypto.Keccak256Hash(delegation)
+				app.EVMKeeper.SetCode(ctx, codeHash.Bytes(), delegation)
+
+				err = app.EVMKeeper.SetAccount(ctx, fromAddr, statedb.Account{
+					Nonce:    0,
+					Balance:  uint256.NewInt(0),
+					CodeHash: codeHash.Bytes(),
+				})
+				require.NoError(t, err)
+
+				// Fund the account with token to pay for the fees
+				amount := sdk.NewCoins(sdk.NewCoin("akii", math.NewInt(20000000*1000000)))
+				err = mintCoins(app, ctx, keys.GetKey(0).AccAddr, amount)
+				require.NoError(t, err)
+
+				return ctx
+			},
+			gasLimit: 20000000,
+			gasPrice: big.NewInt(1000000),
 		},
 	}
 

--- a/x/feeabstraction/ante/evm/mono_decorator_test.go
+++ b/x/feeabstraction/ante/evm/mono_decorator_test.go
@@ -393,7 +393,9 @@ func TestMonoDecorator(t *testing.T) {
 
 				// Build an EIP-7702 delegation designator (0xef0100 || address)
 				// and store it as the account code
-				delegation := append(gethtypes.DelegationPrefix, common.HexToAddress("0x1111111111111111111111111111111111111111").Bytes()...)
+				delegation := make([]byte, 0, len(gethtypes.DelegationPrefix)+common.AddressLength)
+				delegation = append(delegation, gethtypes.DelegationPrefix...)
+				delegation = append(delegation, common.HexToAddress("0x1111111111111111111111111111111111111111").Bytes()...)
 				codeHash := crypto.Keccak256Hash(delegation)
 				app.EVMKeeper.SetCode(ctx, codeHash.Bytes(), delegation)
 


### PR DESCRIPTION
# Description

Fixes F-2026-17891: EIP-7702 delegated EOAs were locked out of sending direct EVM transactions.

Accepts EIP-7702 `SetCodeTx`, but `VerifyIfAccountExists` rejected any account with code.  Once an EOA delegated (bytecode `0xef0100 || address`), it couldn't send further transactions, including the one to revoke its own delegation.

The ante now uses `ethtypes.ParseDelegation` to allow delegation designator code while still rejecting real contract bytecode, matching upstream cosmos/evm. No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```bash
go test -tags=test ./x/feeabstraction/ante/evm/... -run TestMonoDecorator -v
```

- [x] Delegated EOA can send a direct EVM transaction
- [x] Account with real contract code is still rejected (`the sender is not EOA`)

# PR Checklist:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`