### PR TITLE
fix(ante): replace panic with safe return in GovVoteDecorator delegation loop

### DIFF
--- a/ante/gov_vote_ante.go
+++ b/ante/gov_vote_ante.go
@@ -97,7 +97,9 @@ func (g GovVoteDecorator) ValidateVoteMsgs(ctx sdk.Context, msgs []sdk.Msg) erro
 		err = g.stakingKeeper.IterateDelegatorDelegations(ctx, accAddr, func(delegation stakingtypes.Delegation) bool {
 			validatorAddr, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
 			if err != nil {
-				panic(err) // shouldn't happen
+				// Malformed validator address in state: skip this delegation rather
+				// than panicking and halting the node.
+				return false
 			}
 			validator, err := g.stakingKeeper.GetValidator(ctx, validatorAddr)
 			if err == nil {


### PR DESCRIPTION
## Summary

**Bug:** `GovVoteDecorator.ValidateVoteMsgs` called `panic(err)` when `sdk.ValAddressFromBech32` failed inside the `IterateDelegatorDelegations` callback. If a single malformed validator address ends up in staking state, **every governance vote transaction crashes the node**, making governance permanently unusable — a denial-of-service via state corruption.

**Fix:** Return `false` from the iteration callback to skip the bad delegation and continue evaluating the rest.

## Files changed
- `ante/gov_vote_ante.go`