### PR TITLE
fix(rewards): guard CalculateReward against non-positive elapsed time

### DIFF
--- a/x/rewards/types/reward.go
+++ b/x/rewards/types/reward.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"time"
+	time "time"
 
 	"cosmossdk.io/math"
 
@@ -26,6 +26,14 @@ func CalculateReward(blockTime time.Time, schedule ReleaseSchedule) (sdk.Coin, e
 	// Get time parameters
 	timeElapsedStamp := blockTime.Sub(schedule.LastReleaseTime)          // Time since last release
 	totalDurationStamp := schedule.EndTime.Sub(schedule.LastReleaseTime) // Remaining release period
+
+	// Guard: if block time has not advanced past the last release time (e.g.
+	// clock skew or same-block re-entry), return a zero coin to avoid a
+	// negative elapsed duration producing a negative proportion and a
+	// downstream panic in sdk.NewCoin.
+	if timeElapsedStamp.Nanoseconds() <= 0 {
+		return sdk.NewCoin(schedule.TotalAmount.Denom, math.ZeroInt()), nil
+	}
 
 	// Use nanoseconds for precise duration calculations
 	timeElapsedNs := math.NewInt(timeElapsedStamp.Nanoseconds()).BigInt()


### PR DESCRIPTION
## Summary

**Bug:** If `blockTime <= LastReleaseTime` (clock skew, same-block re-entry, or governance setting `LastReleaseTime` close to block time), `timeElapsedNs` was zero or negative.

- Zero: `releaseProportion = 0` — silent no-op, acceptable
- Negative: `releaseProportion < 0` — `amountToRelease < 0` — `sdk.NewCoin` **panics** with "negative coin amount", halting the chain

**Fix:** Return a zero coin early when `timeElapsedStamp.Nanoseconds() <= 0`.

## Files changed
- `x/rewards/types/reward.go`