### PR TITLE
fix(rewards): guard BeginBlocker against clock regression

### DIFF
--- a/x/rewards/keeper/abci.go
+++ b/x/rewards/keeper/abci.go
@@ -41,6 +41,20 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) error {
 		return k.ReleaseSchedule.Set(ctx, schedule)
 	}
 
+	// Guard against clock regression: if the block time has not advanced past
+	// the last release time (e.g. clock skew or a same-block callback), skip
+	// this block. Without this guard, CalculateReward receives a non-positive
+	// elapsed duration and returns zero — or, absent the reward.go guard,
+	// produces a negative coin amount and panics.
+	if !ctx.BlockTime().After(schedule.LastReleaseTime) {
+		k.Logger(ctx).Error(
+			"rewards BeginBlocker: block time has not advanced past last release time — skipping",
+			"block_time", ctx.BlockTime(),
+			"last_release_time", schedule.LastReleaseTime,
+		)
+		return nil
+	}
+
 	// Calculate the amount to distribute this block
 	amountToDistribute, err := types.CalculateReward(ctx.BlockTime(), schedule)
 	if err != nil {


### PR DESCRIPTION
## Summary

**Bug:** `BeginBlocker` had no guard for the case where `ctx.BlockTime() <= schedule.LastReleaseTime`. The only time check was `if schedule.LastReleaseTime.IsZero()`. If block time did not advance (clock skew, replay, same-millisecond blocks in testing), `CalculateReward` was called with a non-positive elapsed duration, producing a zero or — absent the companion `reward.go` guard — a **negative coin amount that panicked `sdk.NewCoin`**.

**Fix:** Return `nil` early when `!ctx.BlockTime().After(schedule.LastReleaseTime)`, logging the anomaly at `ERROR` for operator visibility.

## Files changed
- `x/rewards/keeper/abci.go`