### PR TITLE
fix(rewards): validate denom in FundCommunityPool

### DIFF
--- a/x/rewards/keeper/keeper.go
+++ b/x/rewards/keeper/keeper.go
@@ -76,7 +76,19 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 // The amount is first added to the rewards module account and then directly
 // added to the pool. An error is returned if the amount cannot be sent to the
 // module account.
+// Only coins whose denom matches the module's configured TokenDenom are accepted;
+// funding with a foreign denom would corrupt the single-denom CommunityPool
+// invariant and cause subsequent bank sends to fail.
 func (k Keeper) FundCommunityPool(ctx context.Context, amount sdk.Coin, sender sdk.AccAddress) error {
+	params, err := k.Params.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get module params: %w", err)
+	}
+	if amount.Denom != params.TokenDenom {
+		return fmt.Errorf("cannot fund community pool with denom %s: module only accepts %s",
+			amount.Denom, params.TokenDenom)
+	}
+
 	coins := sdk.Coins{amount}
 	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, types.ModuleName, coins); err != nil {
 		return err


### PR DESCRIPTION
## Summary

**Bug:** `Keeper.FundCommunityPool` accepted any coin denom at the keeper level — the denom check only existed in the `MsgFundPool` handler. If `FundCommunityPool` is called directly (e.g. from a wasm contract binding or future module integration), a wrong-denom deposit would add a foreign coin to `CommunityPool`, breaking the single-denom invariant. Subsequent `BeginBlocker` calls would fail the bank send and halt the chain.

**Fix:** Read module params inside `FundCommunityPool` and reject coins whose denom does not match `TokenDenom` before transferring funds.

## Files changed
- `x/rewards/keeper/keeper.go`