### PR TITLE
fix(rewards): GenesisState.Validate checks CommunityPool covers active schedule

### DIFF
--- a/x/rewards/types/genesis.go
+++ b/x/rewards/types/genesis.go
@@ -50,5 +50,22 @@ func (gs *GenesisState) Validate() error {
 			gs.ReleaseSchedule.TotalAmount.Denom, tokenDenom)
 	}
 
+	// For an active schedule, ensure the CommunityPool holds enough to cover
+	// the remaining release obligations. A deficit at genesis guarantees a
+	// future chain halt once BeginBlocker exhausts the actual bank balance.
+	if gs.ReleaseSchedule.Active {
+		remaining := gs.ReleaseSchedule.TotalAmount.Sub(gs.ReleaseSchedule.ReleasedAmount)
+		if remaining.IsPositive() {
+			poolAmt := gs.RewardPool.CommunityPool.AmountOf(tokenDenom)
+			if poolAmt.TruncateInt().LT(remaining.Amount) {
+				return fmt.Errorf(
+					"community pool (%s %s) is insufficient to cover active schedule remaining amount (%s %s)",
+					poolAmt.TruncateInt(), tokenDenom,
+					remaining.Amount, tokenDenom,
+				)
+			}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Summary

**Bug:** `GenesisState.Validate()` did not verify that `CommunityPool` held enough funds to satisfy the remaining obligations of an active `ReleaseSchedule`. A genesis file where `pool < (TotalAmount - ReleasedAmount)` passed validation successfully, but the chain was guaranteed to halt as soon as `BeginBlocker` exhausted the actual bank balance.

**Fix:** When the schedule is active, compute `remaining = TotalAmount - ReleasedAmount` and reject genesis states where `pool.AmountOf(denom) < remaining`.

## Files changed
- `x/rewards/types/genesis.go`