### PR TITLE
chore: bump evm fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Dependencies
+
+- [EVM](https://github.com/KiiChain/evm) fork from v0.6.0-fork.1 to [v0.6.0-fork.2](https://github.com/KiiChain/evm/releases/tag/v0.6.0-fork.2): bounded internal EVM call gas limit, EVM fee refunds, distribution precompile 32-byte withdraw fix, and CosmWasm EVM query undercharge fix
+
 ### Added
 
 - Emit `update_params`, `fund_pool`, `change_schedule`, and `reward_distributed` events from x/rewards

--- a/go.mod
+++ b/go.mod
@@ -311,6 +311,9 @@ replace (
 	// Use cosmos keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
+	// Use our fork w/ fee abstraction possibility
+	github.com/cosmos/evm => github.com/KiiChain/evm v0.6.0-fork.2
+
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 
@@ -323,6 +326,3 @@ replace (
 	// following versions might cause unexpected behavior
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
-
-replace github.com/cosmos/evm => github.com/KiiChain/evm v0.6.0-fork.2
-

--- a/go.mod
+++ b/go.mod
@@ -325,3 +325,4 @@ replace (
 )
 
 replace github.com/cosmos/evm => github.com/KiiChain/evm v0.6.0-fork.2
+

--- a/go.mod
+++ b/go.mod
@@ -311,9 +311,6 @@ replace (
 	// Use cosmos keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
-	// Use our fork w/ fee abstraction possibility
-	github.com/cosmos/evm => github.com/KiiChain/evm v0.6.0-fork.1
-
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 
@@ -326,3 +323,5 @@ replace (
 	// following versions might cause unexpected behavior
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
+
+replace github.com/cosmos/evm => github.com/KiiChain/evm v0.6.0-fork.2

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXY
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.1.3/go.mod h1:T+2WLyt7VH6Lp0TRxQrUYEs64nRc83wkMQrfeIQKduM=
-github.com/KiiChain/evm v0.6.0-fork.1 h1:lseeoKhzPxSsi6bkyeGPHMAe/unK71wuWtZ0qpQ8Ysg=
-github.com/KiiChain/evm v0.6.0-fork.1/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
+github.com/KiiChain/evm v0.6.0-fork.2 h1:OHk0OI5hIYbHHMWCESHCROErdMcJlofLgpQ6p0TdNmA=
+github.com/KiiChain/evm v0.6.0-fork.2/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=


### PR DESCRIPTION
# Description

Bumps the `cosmos/evm` fork dependency from `v0.6.0-fork.1` to `v0.6.0-fork.2` to pull in recent EVM fixes: bounded internal EVM call gas limit, EVM fee refund handling, distribution precompile 32-byte withdraw address fix, and the CosmWasm EVM query path undercharge fix.

## Type of change

- [x] chore (Updates on dependencies, gitignore, etc)

# How Has This Been Tested?

- [x] `go build ./...` passes against the new tag
- [x] `make test-unit` passes (all packages `ok`, including `wasmbinding/evm`, `x/feeabstraction/ante/evm`, and `tests/integration`)

# PR Checklist:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`