### PR TITLE
fix: block vesting account creation in ante

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Reject `MsgCreateVestingAccount`, `MsgCreatePeriodicVestingAccount`, and `MsgCreatePermanentLockedAccount` in the Cosmos ante (top-level and nested in `authz.MsgExec`) so new vesting / locked accounts cannot be opened after the v7.3.2 upgrade
+
 ### Dependencies
 
 - Bump EVM fork to `v0.6.2-fork.1`, applied via the coordinated `v7.3.2` upgrade (private Cosmos EVM security hotfix; cannot build from public source until 2026-08-28)

--- a/ante/ante_cosmos.go
+++ b/ante/ante_cosmos.go
@@ -29,7 +29,10 @@ func NewCosmosAnteHandler(ctx sdk.Context, options HandlerOptions) sdk.AnteHandl
 		evmcosmosante.NewAuthzLimiterDecorator( // disable the Msg types that cannot be included on an authz.MsgExec msgs field
 			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
 			sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}),
+			sdk.MsgTypeURL(&sdkvesting.MsgCreatePeriodicVestingAccount{}),
+			sdk.MsgTypeURL(&sdkvesting.MsgCreatePermanentLockedAccount{}),
 		),
+		NewVestingAccountCreationDecorator(options.Cdc), // reject vesting-create msgs at the top level and inside authz
 
 		ante.NewSetUpContextDecorator(),
 		oracle.NewVoteAloneDecorator(), // Since this only iterate TXs, it must be executed early

--- a/ante/vesting_ante.go
+++ b/ante/vesting_ante.go
@@ -1,0 +1,71 @@
+package ante
+
+import (
+	errorsmod "cosmossdk.io/errors"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+
+	xerrors "github.com/kiichain/kiichain/v7/x/types/errors"
+)
+
+// blockedVestingCreateMsgs is the set of vesting-module messages that open a
+// new account with LockedCoins. Those accounts are the book the EVM locked-
+// balance snapshot must stay consistent with; new creates are rejected until
+// that path is safe.
+var blockedVestingCreateMsgs = map[string]struct{}{
+	sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}):         {},
+	sdk.MsgTypeURL(&sdkvesting.MsgCreatePeriodicVestingAccount{}): {},
+	sdk.MsgTypeURL(&sdkvesting.MsgCreatePermanentLockedAccount{}): {},
+}
+
+// VestingAccountCreationDecorator rejects messages that create vesting or
+// permanently locked accounts, including when nested in authz.MsgExec.
+type VestingAccountCreationDecorator struct {
+	cdc codec.BinaryCodec
+}
+
+// NewVestingAccountCreationDecorator returns a decorator that blocks new
+// vesting account creation.
+func NewVestingAccountCreationDecorator(cdc codec.BinaryCodec) VestingAccountCreationDecorator {
+	return VestingAccountCreationDecorator{cdc: cdc}
+}
+
+// AnteHandle rejects blocked vesting-create messages at any authz nesting depth.
+func (d VestingAccountCreationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if err := d.validateMsgs(tx.GetMsgs()); err != nil {
+		return ctx, err
+	}
+	return next(ctx, tx, simulate)
+}
+
+func (d VestingAccountCreationDecorator) validateMsgs(msgs []sdk.Msg) error {
+	for _, msg := range msgs {
+		if execMsg, ok := msg.(*authz.MsgExec); ok {
+			if err := d.validateAuthzExec(execMsg); err != nil {
+				return err
+			}
+			continue
+		}
+
+		typeURL := sdk.MsgTypeURL(msg)
+		if _, blocked := blockedVestingCreateMsgs[typeURL]; blocked {
+			return errorsmod.Wrapf(xerrors.ErrUnauthorized, "vesting account creation is disabled: %s", typeURL)
+		}
+	}
+	return nil
+}
+
+func (d VestingAccountCreationDecorator) validateAuthzExec(execMsg *authz.MsgExec) error {
+	innerMsgs := make([]sdk.Msg, 0, len(execMsg.Msgs))
+	for _, v := range execMsg.Msgs {
+		var innerMsg sdk.Msg
+		if err := d.cdc.UnpackAny(v, &innerMsg); err != nil {
+			return errorsmod.Wrapf(xerrors.ErrUnauthorized, "cannot unmarshal authz exec msg (type %s): %v", v.TypeUrl, err)
+		}
+		innerMsgs = append(innerMsgs, innerMsg)
+	}
+	return d.validateMsgs(innerMsgs)
+}

--- a/ante/vesting_ante_internal_test.go
+++ b/ante/vesting_ante_internal_test.go
@@ -1,6 +1,4 @@
-//go:build test
-
-package ante_test
+package ante
 
 import (
 	"testing"
@@ -9,19 +7,29 @@ import (
 
 	"cosmossdk.io/math"
 
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-
-	"github.com/kiichain/kiichain/v7/ante"
-	"github.com/kiichain/kiichain/v7/app/helpers"
 )
 
 func TestVestingAccountCreationDecorator(t *testing.T) {
-	kiiApp := helpers.Setup(t)
+	registry := codectypes.NewInterfaceRegistry()
+	authz.RegisterInterfaces(registry)
+	sdkvesting.RegisterInterfaces(registry)
+	banktypes.RegisterInterfaces(registry)
+	decorator := NewVestingAccountCreationDecorator(codec.NewProtoCodec(registry))
+
 	from := sdk.AccAddress("from________________")
 	to := sdk.AccAddress("to__________________")
 	coins := sdk.NewCoins(sdk.NewCoin("akii", math.NewInt(1)))
+
+	exec := func(msgs ...sdk.Msg) sdk.Msg {
+		m := authz.NewMsgExec(from, msgs)
+		return &m
+	}
 
 	testCases := []struct {
 		name      string
@@ -35,7 +43,6 @@ func TestVestingAccountCreationDecorator(t *testing.T) {
 				ToAddress:   to.String(),
 				Amount:      coins,
 			}},
-			expectErr: false,
 		},
 		{
 			name:      "block MsgCreateVestingAccount",
@@ -62,32 +69,27 @@ func TestVestingAccountCreationDecorator(t *testing.T) {
 		},
 		{
 			name:      "block MsgCreateVestingAccount inside authz.MsgExec",
-			msgs:      []sdk.Msg{newAuthzExec(sdkvesting.NewMsgCreateVestingAccount(from, to, coins, 1, false))},
+			msgs:      []sdk.Msg{exec(sdkvesting.NewMsgCreateVestingAccount(from, to, coins, 1, false))},
 			expectErr: true,
 		},
 		{
-			name:      "block MsgCreatePeriodicVestingAccount inside nested authz.MsgExec",
-			msgs:      []sdk.Msg{newAuthzExec(newAuthzExec(sdkvesting.NewMsgCreatePeriodicVestingAccount(from, to, 1, []sdkvesting.Period{{Length: 1, Amount: coins}})))},
+			name: "block MsgCreatePeriodicVestingAccount inside nested authz.MsgExec",
+			msgs: []sdk.Msg{exec(exec(sdkvesting.NewMsgCreatePeriodicVestingAccount(from, to, 1, []sdkvesting.Period{{
+				Length: 1,
+				Amount: coins,
+			}})))},
 			expectErr: true,
 		},
 		{
 			name:      "block MsgCreatePermanentLockedAccount inside authz.MsgExec",
-			msgs:      []sdk.Msg{newAuthzExec(sdkvesting.NewMsgCreatePermanentLockedAccount(from, to, coins))},
+			msgs:      []sdk.Msg{exec(sdkvesting.NewMsgCreatePermanentLockedAccount(from, to, coins))},
 			expectErr: true,
 		},
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			txCfg := kiiApp.GetTxConfig()
-			decorator := ante.NewVestingAccountCreationDecorator(kiiApp.AppCodec())
-
-			txBuilder := txCfg.NewTxBuilder()
-			require.NoError(t, txBuilder.SetMsgs(tc.msgs...))
-
-			_, err := decorator.AnteHandle(sdk.Context{}, txBuilder.GetTx(), false,
-				func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil })
+			err := decorator.validateMsgs(tc.msgs)
 			if tc.expectErr {
 				require.Error(t, err)
 				require.ErrorContains(t, err, "vesting account creation is disabled")

--- a/ante/vesting_ante_test.go
+++ b/ante/vesting_ante_test.go
@@ -1,0 +1,99 @@
+//go:build test
+
+package ante_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/kiichain/kiichain/v7/ante"
+	"github.com/kiichain/kiichain/v7/app/helpers"
+)
+
+func TestVestingAccountCreationDecorator(t *testing.T) {
+	kiiApp := helpers.Setup(t)
+	from := sdk.AccAddress("from________________")
+	to := sdk.AccAddress("to__________________")
+	coins := sdk.NewCoins(sdk.NewCoin("akii", math.NewInt(1)))
+
+	testCases := []struct {
+		name      string
+		msgs      []sdk.Msg
+		expectErr bool
+	}{
+		{
+			name: "allow bank send",
+			msgs: []sdk.Msg{&banktypes.MsgSend{
+				FromAddress: from.String(),
+				ToAddress:   to.String(),
+				Amount:      coins,
+			}},
+			expectErr: false,
+		},
+		{
+			name:      "block MsgCreateVestingAccount",
+			msgs:      []sdk.Msg{sdkvesting.NewMsgCreateVestingAccount(from, to, coins, 1, false)},
+			expectErr: true,
+		},
+		{
+			name:      "block delayed MsgCreateVestingAccount",
+			msgs:      []sdk.Msg{sdkvesting.NewMsgCreateVestingAccount(from, to, coins, 1, true)},
+			expectErr: true,
+		},
+		{
+			name: "block MsgCreatePeriodicVestingAccount",
+			msgs: []sdk.Msg{sdkvesting.NewMsgCreatePeriodicVestingAccount(from, to, 1, []sdkvesting.Period{{
+				Length: 1,
+				Amount: coins,
+			}})},
+			expectErr: true,
+		},
+		{
+			name:      "block MsgCreatePermanentLockedAccount",
+			msgs:      []sdk.Msg{sdkvesting.NewMsgCreatePermanentLockedAccount(from, to, coins)},
+			expectErr: true,
+		},
+		{
+			name:      "block MsgCreateVestingAccount inside authz.MsgExec",
+			msgs:      []sdk.Msg{newAuthzExec(sdkvesting.NewMsgCreateVestingAccount(from, to, coins, 1, false))},
+			expectErr: true,
+		},
+		{
+			name:      "block MsgCreatePeriodicVestingAccount inside nested authz.MsgExec",
+			msgs:      []sdk.Msg{newAuthzExec(newAuthzExec(sdkvesting.NewMsgCreatePeriodicVestingAccount(from, to, 1, []sdkvesting.Period{{Length: 1, Amount: coins}})))},
+			expectErr: true,
+		},
+		{
+			name:      "block MsgCreatePermanentLockedAccount inside authz.MsgExec",
+			msgs:      []sdk.Msg{newAuthzExec(sdkvesting.NewMsgCreatePermanentLockedAccount(from, to, coins))},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			txCfg := kiiApp.GetTxConfig()
+			decorator := ante.NewVestingAccountCreationDecorator(kiiApp.AppCodec())
+
+			txBuilder := txCfg.NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(tc.msgs...))
+
+			_, err := decorator.AnteHandle(sdk.Context{}, txBuilder.GetTx(), false,
+				func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil })
+			if tc.expectErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "vesting account creation is disabled")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Block creation of new vesting and permanently locked accounts after the v7.3.2 upgrade.

Those account types carry `LockedCoins` that the EVM spendable snapshot has to stay consistent with. New creates are rejected in the Cosmos ante as a top-level tx and when nested in `authz.MsgExec`. Existing vesting accounts are unchanged.

Blocked messages:

- `MsgCreateVestingAccount`
- `MsgCreatePeriodicVestingAccount`
- `MsgCreatePermanentLockedAccount`

`AuthzLimiterDecorator` now includes Periodic and PermanentLocked as well (CreateVesting was already there).

Depends on the v7.3.2 upgrade / EVM hotfix already on this branch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go test -mod=readonly -tags=test ./ante -count=1 -run TestVestingAccountCreationDecorator`
  - bank send still allowed
  - all three create msgs rejected
  - delayed vesting rejected
  - create msgs nested in `authz.MsgExec` (including nested exec) rejected
- [x] `make lint-fix`

# PR Checklist:

- [x] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`