### PR TITLE
fix: Enhance upgrade sweep

### DIFF
--- a/app/blockedaddrs/addrs.go
+++ b/app/blockedaddrs/addrs.go
@@ -2,6 +2,7 @@ package blockedaddrs
 
 import (
 	"encoding/hex"
+	"sort"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -31,6 +32,21 @@ var AttackerAddrs = map[string]string{
 	"kii16tr429kvneexqf4jttueuecm75ptc5l3gtj34q": "0xd2c75516cc9e726026b25af99e671bf502bc53f1",
 	"kii1mkhdmdgklsskgcgzz699nzhafav2hkea4qp2dj": "0xddaeddb516fc21646102168a598afd4f58abdb3d",
 	"kii1a5v3eaeaugdh3vk57nlh8q8xcu7z46w0ttlrw9": "0xed191cf73de21b78b2d4f4ff7380e6c73c2ae9cf",
+}
+
+// SortedAttackerAddresses returns AttackerAddrs' keys in a fixed,
+// deterministic order. Range over AttackerAddrs directly only where
+// iteration order can't matter (e.g. IsBlockedAccAddress's lookup) — Go
+// randomizes map iteration order per process, and code that walks this list
+// from a consensus-critical upgrade handler must behave identically, in the
+// same order, on every validator.
+func SortedAttackerAddresses() []string {
+	addrs := make([]string, 0, len(AttackerAddrs))
+	for addr := range AttackerAddrs {
+		addrs = append(addrs, addr)
+	}
+	sort.Strings(addrs)
+	return addrs
 }
 
 // IsBlockedAccAddress reports whether addr is one of AttackerAddrs.

--- a/app/blockedaddrs/addrs_test.go
+++ b/app/blockedaddrs/addrs_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	// Sets the global "kii" bech32 prefix via its init(), same as the real
 	// binary — without this, sdk.AccAddressFromBech32 rejects "kii1..."
 	// addresses (default prefix is "cosmos").
 	_ "github.com/kiichain/kiichain/v7/app/params"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func TestIsBlockedAddr(t *testing.T) {

--- a/app/upgrades/v7_4/upgrade.go
+++ b/app/upgrades/v7_4/upgrade.go
@@ -106,38 +106,82 @@ func recoverFunds(ctx sdk.Context, k *keepers.AppKeepers) error {
 		return fmt.Errorf("invalid staging address: %w", err)
 	}
 
-	if err := sweepAttackerFunds(ctx, k, staging); err != nil {
+	sweptAKII, err := sweepAttackerFunds(ctx, k, staging)
+	if err != nil {
 		return err
+	}
+
+	payoutTotal, err := totalPayoutAmount()
+	if err != nil {
+		return err
+	}
+
+	if sweptAKII.LT(payoutTotal) {
+		return fmt.Errorf("insufficient recovered akii: swept=%s payouts=%s", sweptAKII, payoutTotal)
 	}
 
 	if err := distributePayouts(ctx, k, staging); err != nil {
 		return err
 	}
 
-	return distributeRemainder(ctx, k, staging)
+	remainderAmount := sweptAKII.Sub(payoutTotal)
+	return distributeRemainder(ctx, k, staging, remainderAmount)
 }
 
-// sweepAttackerFunds moves every attacker wallet's full balance into staging
-// These are plain accounts/contracts, not vesting accounts, so a direct
-// bank transfer is all that's needed
-func sweepAttackerFunds(ctx sdk.Context, k *keepers.AppKeepers, staging sdk.AccAddress) error {
-	for addrStr := range blockedaddrs.AttackerAddrs {
+// totalPayoutAmount sums payouts with math.Int, so recoverFunds can compare
+// it against what was actually swept before moving anything out of staging.
+func totalPayoutAmount() (math.Int, error) {
+	total := math.ZeroInt()
+	for _, p := range payouts {
+		amount, ok := math.NewIntFromString(p.amount)
+		if !ok {
+			return math.ZeroInt(), fmt.Errorf("invalid payout amount %q for %s", p.amount, p.addr)
+		}
+		total = total.Add(amount)
+	}
+	return total, nil
+}
+
+// sweepAttackerFunds moves every attacker wallet's akii balance into staging
+// and returns the total amount actually swept. These are plain
+// accounts/contracts, not vesting accounts, so a direct bank transfer of
+// just the akii balance (not GetAllBalances) is all that's needed.
+//
+// Iterates blockedaddrs.SortedAttackerAddresses(), not the map directly:
+// Go's map iteration order is randomized per process, and every validator
+// must run this in the same order for identical behavior.
+func sweepAttackerFunds(ctx sdk.Context, k *keepers.AppKeepers, staging sdk.AccAddress) (math.Int, error) {
+	stagingBefore := k.BankKeeper.GetBalance(ctx, staging, denom)
+	sweptAKII := math.ZeroInt()
+
+	for _, addrStr := range blockedaddrs.SortedAttackerAddresses() {
 		attackerAddr, err := sdk.AccAddressFromBech32(addrStr)
 		if err != nil {
-			return fmt.Errorf("invalid attacker address %s: %w", addrStr, err)
+			return math.ZeroInt(), fmt.Errorf("invalid attacker address %s: %w", addrStr, err)
 		}
 
-		balance := k.BankKeeper.GetAllBalances(ctx, attackerAddr)
-		if balance.IsZero() {
+		coin := k.BankKeeper.GetBalance(ctx, attackerAddr, denom)
+		if coin.IsZero() {
 			continue
 		}
-		if err := k.BankKeeper.SendCoins(ctx, attackerAddr, staging, balance); err != nil {
-			return fmt.Errorf("sweep from %s: %w", addrStr, err)
+
+		if err := k.BankKeeper.SendCoins(ctx, attackerAddr, staging, sdk.NewCoins(coin)); err != nil {
+			return math.ZeroInt(), fmt.Errorf("sweep from %s: %w", addrStr, err)
 		}
-		ctx.Logger().Info("emergency-fix: swept to staging", "addr", addrStr, "amount", balance.String())
+
+		ctx.Logger().Info("emergency-fix: swept to staging", "addr", addrStr, "amount", coin.String())
+		sweptAKII = sweptAKII.Add(coin.Amount)
 	}
 
-	return nil
+	// Validate the amount swept matches the difference in staging's akii
+	// balance before and after.
+	stagingAfter := k.BankKeeper.GetBalance(ctx, staging, denom)
+	if !stagingAfter.Amount.Equal(stagingBefore.Amount.Add(sweptAKII)) {
+		return math.ZeroInt(), fmt.Errorf("swept akii %s does not match staging balance change %s",
+			sweptAKII.String(), stagingAfter.Amount.Sub(stagingBefore.Amount).String())
+	}
+
+	return sweptAKII, nil
 }
 
 // distributePayouts sends each payout out of staging, in the order listed
@@ -163,21 +207,23 @@ func distributePayouts(ctx sdk.Context, k *keepers.AppKeepers, staging sdk.AccAd
 	return nil
 }
 
-// distributeRemainder sends whatever is left in staging to remainderAddr.
-func distributeRemainder(ctx sdk.Context, k *keepers.AppKeepers, staging sdk.AccAddress) error {
+// distributeRemainder sends exactly amount (swept minus paid out, computed
+// by the caller) from staging to remainderAddr.
+func distributeRemainder(ctx sdk.Context, k *keepers.AppKeepers, staging sdk.AccAddress, amount math.Int) error {
 	remainder, err := sdk.AccAddressFromBech32(remainderAddr)
 	if err != nil {
 		return fmt.Errorf("invalid remainder address: %w", err)
 	}
 
-	balance := k.BankKeeper.GetAllBalances(ctx, staging)
-	if balance.IsZero() {
+	if !amount.IsPositive() {
 		return nil
 	}
-	if err := k.BankKeeper.SendCoins(ctx, staging, remainder, balance); err != nil {
+
+	coins := sdk.NewCoins(sdk.NewCoin(denom, amount))
+	if err := k.BankKeeper.SendCoins(ctx, staging, remainder, coins); err != nil {
 		return fmt.Errorf("remainder distribution: %w", err)
 	}
-	ctx.Logger().Info("emergency-fix: remainder distributed", "amount", balance.String())
+	ctx.Logger().Info("emergency-fix: remainder distributed", "amount", coins.String())
 
 	return nil
 }

--- a/app/upgrades/v7_4/upgrade_test.go
+++ b/app/upgrades/v7_4/upgrade_test.go
@@ -11,6 +11,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
 	kiichain "github.com/kiichain/kiichain/v7/app"
 	"github.com/kiichain/kiichain/v7/app/blockedaddrs"
 	kiihelpers "github.com/kiichain/kiichain/v7/app/helpers"
@@ -61,6 +63,17 @@ func fund(t *testing.T, app *kiichain.KiichainApp, ctx sdk.Context, addr string,
 	coins := sdk.NewCoins(sdk.NewCoin(denom, amount))
 	require.NoError(t, app.BankKeeper.MintCoins(ctx, tokenfactorytypes.ModuleName, coins))
 	require.NoError(t, app.BankKeeper.SendCoinsFromModuleToAccount(ctx, tokenfactorytypes.ModuleName, sdk.MustAccAddressFromBech32(addr), coins))
+}
+
+// fundStaging mints coins via tokenfactory and sends them into the "evm"
+// module account by name. stagingAddr is a real module account, and bank's
+// SendCoinsFromModuleToAccount rejects it as a recipient (blocked-address
+// check), so module-to-module is the only way to fund it directly in a test.
+func fundStaging(t *testing.T, app *kiichain.KiichainApp, ctx sdk.Context, amount math.Int) {
+	t.Helper()
+	coins := sdk.NewCoins(sdk.NewCoin(denom, amount))
+	require.NoError(t, app.BankKeeper.MintCoins(ctx, tokenfactorytypes.ModuleName, coins))
+	require.NoError(t, app.BankKeeper.SendCoinsFromModuleToModule(ctx, tokenfactorytypes.ModuleName, evmtypes.ModuleName, coins))
 }
 
 // totalPayouts sums payouts using math.Int so the huge amounts aren't
@@ -122,6 +135,36 @@ func TestCreateUpgradeHandler_RecoversAndRedistributesFunds(t *testing.T) {
 
 	// Freeze turns on only after recoverFunds, so the sweep above can succeed.
 	require.True(t, blockedaddrs.IsEnabled(ctx, app.GetKey(banktypes.StoreKey)))
+}
+
+// TestCreateUpgradeHandler_RemainderExcludesPreexistingStagingBalance is a
+// regression test: stagingAddr is the real "evm" module account, so it can
+// hold akii that has nothing to do with this recovery. The remainder step
+// must send only (swept - payouts), never staging's full balance.
+func TestCreateUpgradeHandler_RemainderExcludesPreexistingStagingBalance(t *testing.T) {
+	app, ctx := kiihelpers.SetupWithContext(t)
+	ctx = ctx.WithChainID(v740.MainnetChainID).WithBlockHeight(v740.UpgradeHeight)
+
+	// staging already holds akii unrelated to the incident before the
+	// handler ever runs.
+	preexisting := math.NewIntWithDecimal(777, 18)
+	fundStaging(t, app, ctx, preexisting)
+
+	extraRemainder := math.NewIntWithDecimal(500, 18)
+	fund(t, app, ctx, attacker1, totalPayouts(t).Add(extraRemainder))
+
+	mm := app.GetModuleManager()
+	handler := v740.CreateUpgradeHandler(mm, app.GetConfigurator(), &app.AppKeepers)
+	_, err := handler(ctx, upgradetypes.Plan{Name: v740.UpgradeName}, mm.GetVersionMap())
+	require.NoError(t, err)
+
+	// Only the swept-minus-payouts delta reached remainderAddr...
+	gotRemainder := app.BankKeeper.GetBalance(ctx, sdk.MustAccAddressFromBech32(remainderAddr), denom)
+	require.Equal(t, extraRemainder.String(), gotRemainder.Amount.String())
+
+	// ...and staging's pre-existing balance was left exactly where it was.
+	stagingBal := app.BankKeeper.GetBalance(ctx, sdk.MustAccAddressFromBech32(stagingAddr), denom)
+	require.Equal(t, preexisting.String(), stagingBal.Amount.String())
 }
 
 // TestCreateUpgradeHandler_PanicsWhenStagingCannotCoverPayouts verifies the


### PR DESCRIPTION
# Description

These changes make the following:
- Scope the attacker-wallet sweep to the native denom only, tracking the exact amount swept instead of trusting the staging account's balance.
- Compute the recovery remainder as swept minus payouts, so the staging account's own balance is never swept into it.
- Fail closed with a clear error if the swept amount can't cover the payout list.
- Iterate the attacker address list in a fixed, sorted order instead of a map's iteration order, so every validator behaves identically.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests covering the sweep/payout/remainder math, fail-closed on insufficient recovered funds, and the no-op path on non-mainnet chain-ids
- [x] Full existing test suite (`go test ./...`) run clean against these changes

# PR Checklist:

Make sure each step was done:

- [ ] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
