### PR TITLE
fix: Use speandable on sweep attackers funds

### DIFF
--- a/app/upgrades/v7_4/upgrade.go
+++ b/app/upgrades/v7_4/upgrade.go
@@ -171,10 +171,11 @@ func totalPayoutAmount() (math.Int, error) {
 	return total, nil
 }
 
-// sweepAttackerFunds moves every attacker wallet's akii balance into staging
-// and returns the total amount actually swept. These are plain
-// accounts/contracts, not vesting accounts, so a direct bank transfer of
-// just the akii balance (not GetAllBalances) is all that's needed.
+// sweepAttackerFunds moves each attacker wallet's spendable akii balance
+// into staging and returns the total amount actually swept. Uses
+// SpendableCoin rather than GetBalance: some attacker addresses are vesting
+// accounts, so this may recover less than the full balance for those,
+// leaving any locked remainder in place.
 //
 // Iterates blockedaddrs.SortedAttackerAddresses(), not the map directly:
 // Go's map iteration order is randomized per process, and every validator
@@ -189,7 +190,7 @@ func sweepAttackerFunds(ctx sdk.Context, k *keepers.AppKeepers, staging sdk.AccA
 			return math.ZeroInt(), fmt.Errorf("invalid attacker address %s: %w", addrStr, err)
 		}
 
-		coin := k.BankKeeper.GetBalance(ctx, attackerAddr, denom)
+		coin := k.BankKeeper.SpendableCoin(ctx, attackerAddr, denom)
 		if coin.IsZero() {
 			continue
 		}
@@ -299,7 +300,7 @@ func captureInvariantSnapshot(ctx sdk.Context, k *keepers.AppKeepers, staging sd
 // exactly:
 //   - total akii supply is unchanged — this recovery only ever moves
 //     existing coins between accounts, it never mints or burns.
-//   - every attacker wallet ended at exactly zero.
+//   - every attacker wallet has nothing left spendable.
 //   - staging (the evm module account) is back to its pre-recovery
 //     balance — everything swept in was paid back out exactly, none of
 //     staging's own funds were touched.
@@ -321,8 +322,9 @@ func verifyInvariants(ctx sdk.Context, k *keepers.AppKeepers, staging sdk.AccAdd
 		if err != nil {
 			return fmt.Errorf("invalid attacker address %s: %w", addrStr, err)
 		}
-		if balance := k.BankKeeper.GetBalance(ctx, addr, denom); !balance.IsZero() {
-			return fmt.Errorf("invariant violated: attacker %s still holds %s", addrStr, balance)
+
+		if spendable := k.BankKeeper.SpendableCoin(ctx, addr, denom); !spendable.IsZero() {
+			return fmt.Errorf("invariant violated: attacker %s still has %s spendable", addrStr, spendable)
 		}
 	}
 

--- a/app/upgrades/v7_4/upgrade_test.go
+++ b/app/upgrades/v7_4/upgrade_test.go
@@ -9,6 +9,8 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	evmtypes "github.com/cosmos/evm/x/vm/types"
@@ -135,6 +137,53 @@ func TestCreateUpgradeHandler_RecoversAndRedistributesFunds(t *testing.T) {
 
 	// Freeze turns on only after recoverFunds, so the sweep above can succeed.
 	require.True(t, blockedaddrs.IsEnabled(ctx, app.GetKey(banktypes.StoreKey)))
+}
+
+// TestCreateUpgradeHandler_SweepsOnlySpendableFromVestingAccount is a
+// regression test for a real vesting account found among the attacker
+// wallets during testing (the incident's own attack vehicle was a staged
+// DelayedVestingAccount — see the root-cause analysis). Most of its balance
+// is locked for a year; the sweep must recover exactly the spendable
+// portion and leave the locked remainder untouched, rather than failing
+// outright or force-unlocking the account.
+func TestCreateUpgradeHandler_SweepsOnlySpendableFromVestingAccount(t *testing.T) {
+	app, ctx := kiihelpers.SetupWithContext(t)
+	ctx = ctx.WithChainID(v740.MainnetChainID).WithBlockHeight(v740.UpgradeHeight)
+
+	// attacker2 is a normal account funded with enough to cover the fixed
+	// payout list on its own, so the vesting account below only needs to
+	// demonstrate the partial-sweep behavior, not carry the whole recovery.
+	fund(t, app, ctx, attacker2, totalPayouts(t))
+
+	// attacker1 is staged as a vesting account: most of its balance is
+	// locked for a year, only 2 KII (matching the real incident's setup) is
+	// currently spendable.
+	spendable := math.NewIntWithDecimal(2, 18)
+	locked := math.NewIntWithDecimal(1000, 18)
+	fund(t, app, ctx, attacker1, spendable.Add(locked))
+
+	attackerAddr := sdk.MustAccAddressFromBech32(attacker1)
+	baseAcc, ok := app.AccountKeeper.GetAccount(ctx, attackerAddr).(*authtypes.BaseAccount)
+	require.True(t, ok, "expected a plain BaseAccount to wrap into a vesting account")
+	vestingAcc, err := vestingtypes.NewDelayedVestingAccount(
+		baseAcc,
+		sdk.NewCoins(sdk.NewCoin(denom, locked)),
+		ctx.BlockTime().AddDate(1, 0, 0).Unix(), // locked for a full year — nothing has vested yet
+	)
+	require.NoError(t, err)
+	app.AccountKeeper.SetAccount(ctx, vestingAcc)
+	require.Equal(t, spendable.String(), app.BankKeeper.SpendableCoin(ctx, attackerAddr, denom).Amount.String(),
+		"sanity check: only the top-up should be spendable before the sweep runs")
+
+	mm := app.GetModuleManager()
+	handler := v740.CreateUpgradeHandler(mm, app.GetConfigurator(), &app.AppKeepers)
+	_, err = handler(ctx, upgradetypes.Plan{Name: v740.UpgradeName}, mm.GetVersionMap())
+	require.NoError(t, err)
+
+	// Only the spendable slice was swept out of the vesting account; the
+	// locked remainder is left exactly where it was, by design.
+	require.True(t, app.BankKeeper.SpendableCoin(ctx, attackerAddr, denom).IsZero())
+	require.Equal(t, locked.String(), app.BankKeeper.GetBalance(ctx, attackerAddr, denom).Amount.String())
 }
 
 // TestCreateUpgradeHandler_RemainderExcludesPreexistingStagingBalance is a


### PR DESCRIPTION
# Description

Fixes the attacker-wallet sweep to account for vesting accounts correctly and generically. Testing surfaced a real vesting account among the attacker wallets (the incident's own attack vehicle was a staged `DelayedVestingAccount`) — a plain `GetBalance` + `SendCoins` fails for it, since `x/bank` only allows moving the currently-unlocked ("spendable") portion, capped by the account's vesting schedule regardless of its total balance.

Replaces `GetBalance` with `BankKeeper.SpendableCoin(addr, denom)` in the sweep, which computes balance-minus-locked generically for any address — no hardcoded address or amount needed. For normal accounts this is identical to before (nothing is locked). For a vesting account, it sweeps exactly what's currently spendable and deliberately leaves any locked remainder in place, rather than force-unlocking the account.

Updated the "every attacker balance is zero" invariant to "every attacker has nothing left spendable," matching this behavior — a vesting account can legitimately still hold a locked balance after the sweep.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] New unit test: stages a real vesting account (`DelayedVestingAccount`, most of its balance locked for a year) among the attacker wallets, confirms the sweep recovers exactly the spendable portion and leaves the locked remainder untouched, and that the full handler (including the invariant checks) completes without error
- [x] Existing recovery-handler tests (full sweep/payout/remainder happy path, insufficient-funds fail-closed, non-mainnet no-op, remainder excludes staging's pre-existing balance) still pass unchanged

# PR Checklist:

Make sure each step was done:

- [ ] Updated changelog with PR's intent
- [x] Lint with `make lint-fix`
